### PR TITLE
feat: 회원가입 및 아이디/닉네임 중복 체크 API 구현

### DIFF
--- a/src/docs/asciidoc/index.adoc
+++ b/src/docs/asciidoc/index.adoc
@@ -1,0 +1,84 @@
+//  REST API Documentation
+// :doctype: book
+// :icons: font
+// :source-highlighter: coderay
+// :toc: left
+// :toclevels: 3
+// :sectlinks:
+
+// 이 문서는 buythedip REST API의 사용법을 설명합니다.
+
+
+
+:toc: left
+
+++++
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const toc = document.getElementById('toc');
+    if (toc) {
+        const lists = toc.querySelectorAll('ul ul');
+        lists.forEach(function(ul) {
+            ul.style.display = 'none';
+            const parentLi = ul.parentElement;
+            if (parentLi && parentLi.querySelector('a')) {
+                const btn = document.createElement('span');
+                btn.textContent = ' [+] ';
+                btn.style.cursor = 'pointer';
+                btn.style.color = '#06c';
+                btn.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    if (ul.style.display === 'none') {
+                        ul.style.display = '';
+                        btn.textContent = ' [-] ';
+                    } else {
+                        ul.style.display = 'none';
+                        btn.textContent = ' [+] ';
+                    }
+                });
+                parentLi.insertBefore(btn, parentLi.firstChild);
+            }
+        });
+    }
+});
+</script>
+++++
+
+== User API
+
+=== 회원가입 - 성공
+
+include::{snippets}/signup-success/http-request.adoc[]
+include::{snippets}/signup-success/request-fields.adoc[]
+include::{snippets}/signup-success/http-response.adoc[]
+include::{snippets}/signup-success/response-fields.adoc[]
+
+=== 회원가입 시 계정 ID 중복 체크 - 성공
+
+include::{snippets}/auth-check-availability-conflict-account-id-success/http-request.adoc[]
+include::{snippets}/auth-check-availability-conflict-account-id-success/request-fields.adoc[]
+include::{snippets}/auth-check-availability-conflict-account-id-success/http-response.adoc[]
+include::{snippets}/auth-check-availability-conflict-account-id-success/response-fields.adoc[]
+
+=== 회원가입 시 계정 ID 중복 - 실패
+
+include::{snippets}/auth-check-availability-conflict-account-id-fail/http-request.adoc[]
+include::{snippets}/auth-check-availability-conflict-account-id-fail/request-fields.adoc[]
+include::{snippets}/auth-check-availability-conflict-account-id-fail/http-response.adoc[]
+include::{snippets}/auth-check-availability-conflict-account-id-fail/response-fields.adoc[]
+
+=== 회원가입 시 닉네임 중복 체크 - 성공
+
+include::{snippets}/auth-check-availability-conflict-nickname-success/http-request.adoc[]
+include::{snippets}/auth-check-availability-conflict-nickname-success/request-fields.adoc[]
+include::{snippets}/auth-check-availability-conflict-nickname-success/http-response.adoc[]
+include::{snippets}/auth-check-availability-conflict-nickname-success/response-fields.adoc[]
+
+{empty}
+
+=== 회원가입 시 닉네임 중복 체크 - 실패
+
+include::{snippets}/auth-check-availability-conflict-nickname-fail/http-request.adoc[]
+include::{snippets}/auth-check-availability-conflict-nickname-fail/request-fields.adoc[]
+include::{snippets}/auth-check-availability-conflict-nickname-fail/http-response.adoc[]
+include::{snippets}/auth-check-availability-conflict-nickname-fail/response-fields.adoc[]

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/BuythedipKotlinApplication.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/BuythedipKotlinApplication.kt
@@ -1,0 +1,12 @@
+package com.zunza.buythedip_kotlin
+
+import org.springframework.boot.autoconfigure.SpringBootApplication
+import org.springframework.boot.runApplication
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing
+
+@SpringBootApplication
+class BuythedipKotlinApplication
+
+fun main(args: Array<String>) {
+	runApplication<BuythedipKotlinApplication>(*args)
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/common/ApiResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/common/ApiResponse.kt
@@ -1,0 +1,10 @@
+package com.zunza.buythedip_kotlin.common
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+data class ApiResponse<T> (
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val data: T,
+    val code: Int,
+    val success: Boolean = code >= 200 && code < 300
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/common/CustomException.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/common/CustomException.kt
@@ -1,0 +1,5 @@
+package com.zunza.buythedip_kotlin.common
+
+abstract class CustomException(message: String) : RuntimeException(message) {
+    abstract fun getStatusCode(): Int;
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/common/ErrorResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/common/ErrorResponse.kt
@@ -1,0 +1,11 @@
+package com.zunza.buythedip_kotlin.common
+
+import com.fasterxml.jackson.annotation.JsonInclude
+
+data class ErrorResponse(
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val message: String? = null,
+
+    @JsonInclude(JsonInclude.Include.NON_NULL)
+    val messages: List<String>? = null
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/common/GlobalResponseAdvice.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/common/GlobalResponseAdvice.kt
@@ -1,0 +1,51 @@
+package com.zunza.buythedip_kotlin.common
+
+import jakarta.servlet.http.HttpServletResponse
+import jakarta.servlet.http.HttpServletResponse.*
+import org.springframework.core.MethodParameter
+import org.springframework.http.MediaType
+import org.springframework.http.ResponseEntity
+import org.springframework.http.converter.HttpMessageConverter
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.web.bind.annotation.ExceptionHandler
+import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.servlet.mvc.method.annotation.ResponseBodyAdvice
+
+@RestControllerAdvice
+class GlobalResponseAdvice(
+    private val httpServletResponse: HttpServletResponse
+) : ResponseBodyAdvice<Any> {
+
+    override fun supports(
+        returnType: MethodParameter,
+        converterType: Class<out HttpMessageConverter<*>?>
+    ): Boolean {
+        return returnType.containingClass.isAnnotationPresent(RestController::class.java)
+    }
+
+    override fun beforeBodyWrite(
+        body: Any?,
+        returnType: MethodParameter,
+        selectedContentType: MediaType,
+        selectedConverterType: Class<out HttpMessageConverter<*>?>,
+        request: ServerHttpRequest,
+        response: ServerHttpResponse
+    ): Any? {
+        val status: Int = httpServletResponse.status
+
+        return when (body) {
+            is ApiResponse<*> -> body
+            null -> ApiResponse(null, status)
+            else -> ApiResponse(body, status)
+        }
+    }
+
+    @ExceptionHandler(CustomException::class)
+    fun customExceptionHandler(e: CustomException): ResponseEntity<ApiResponse<ErrorResponse>> {
+        val errorResponse = ErrorResponse(e.message)
+        val apiResponse = ApiResponse(errorResponse, e.getStatusCode())
+        return ResponseEntity.status(e.getStatusCode()).body(apiResponse)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/SecurityConfig.kt
@@ -1,0 +1,39 @@
+package com.zunza.buythedip_kotlin.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.security.config.annotation.web.builders.HttpSecurity
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
+import org.springframework.security.config.http.SessionCreationPolicy
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.security.web.SecurityFilterChain
+
+@Configuration
+@EnableWebSecurity
+class SecurityConfig {
+
+    @Bean
+    fun passwordEncoder(): PasswordEncoder {
+        return BCryptPasswordEncoder()
+    }
+
+    @Bean
+    fun securityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        http
+            .csrf { it.disable() }
+            .httpBasic { it.disable() }
+            .formLogin { it.disable() }
+            .logout { it.disable() }
+            .sessionManagement {
+                it.sessionCreationPolicy(SessionCreationPolicy.STATELESS)
+            }
+
+            .authorizeHttpRequests { authorize ->
+                authorize
+                    .anyRequest().permitAll()
+            }
+
+        return http.build()
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/controller/AuthController.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/controller/AuthController.kt
@@ -1,0 +1,32 @@
+package com.zunza.buythedip_kotlin.user.controller
+
+import com.zunza.buythedip_kotlin.user.dto.SignupRequest
+import com.zunza.buythedip_kotlin.user.dto.ValidationRequest
+import com.zunza.buythedip_kotlin.user.service.AuthService
+import jakarta.servlet.http.HttpServletResponse.*
+import jakarta.validation.Valid
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class AuthController(
+    private val authService: AuthService
+) {
+    @PostMapping("/api/auth/validation/check-availability")
+    fun checkAvailability(
+        @RequestBody validationRequest: ValidationRequest
+    ): ResponseEntity<Unit> {
+        authService.checkAvailability(validationRequest)
+        return ResponseEntity.status(SC_OK).build()
+    }
+
+    @PostMapping("/api/auth/signup")
+    fun signup(
+        @Valid @RequestBody signupRequest: SignupRequest
+    ): ResponseEntity<Unit> {
+        authService.signup(signupRequest)
+        return ResponseEntity.status(SC_CREATED).build()
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/dto/SignupRequest.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/dto/SignupRequest.kt
@@ -1,0 +1,26 @@
+package com.zunza.buythedip_kotlin.user.dto
+
+import jakarta.validation.constraints.NotBlank
+import jakarta.validation.constraints.Pattern
+import jakarta.validation.constraints.Size
+
+data class SignupRequest(
+
+    @field:NotBlank(message = "아이디는 필수 입력 값입니다.")
+    @Size(min = 6, max = 20, message = "아이디는 6자 이상 20자 이하로 입력해주세요.")
+    @Pattern(regexp = "^[a-z0-9]+$", message = "아이디는 영문 소문자와 숫자만 사용 가능합니다.")
+    val accountId: String,
+
+    @field:NotBlank(message = "비밀번호는 필수 입력 값입니다.")
+    @Size(min = 8, max = 24, message = "비밀번호는 8자 이상 24자 이하로 입력해주세요.")
+    @Pattern(
+        regexp = "^(?=.*[a-zA-Z])(?=.*\\d)(?=.*[@$!%*?&])[A-Za-z\\d@$!%*?&]{8,}$",
+        message = "비밀번호는 8자 이상이며, 영문자, 숫자, 특수문자를 최소 1개 이상 포함해야 합니다."
+    )
+    val password: String,
+
+    @field:NotBlank(message = "닉네임은 필수 입력 값입니다.")
+    @Size(min = 2, max = 10, message = "닉네임은 2자 이상 10자 이하로 입력해주세요.")
+    @Pattern(regexp = "^[a-zA-Z0-9가-힣]+$", message = "닉네임은 한글, 영문자, 숫자만 사용 가능합니다.")
+    val nickname: String
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/dto/ValidationRequest.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/dto/ValidationRequest.kt
@@ -1,0 +1,27 @@
+package com.zunza.buythedip_kotlin.user.dto
+
+import com.fasterxml.jackson.annotation.JsonCreator
+import com.fasterxml.jackson.annotation.JsonValue
+
+data class ValidationRequest(
+    val validationType: ValidationType,
+    val value: String
+) {
+    enum class ValidationType(
+        @JsonValue
+        val fieldName: String
+    ) {
+        ACCOUNT_ID("accountId"),
+        NICKNAME("nickname");
+
+        @JsonCreator
+        fun deserialize(fieldName: String): ValidationType? {
+            for (type in ValidationType.entries) {
+                if (fieldName == type.fieldName) {
+                    return type
+                }
+            }
+            return null
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/entity/User.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/entity/User.kt
@@ -1,0 +1,50 @@
+package com.zunza.buythedip_kotlin.user.entity
+
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class User private constructor(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    @Column(nullable = false, unique = true)
+    val accountId: String,
+
+    @Column(nullable = false)
+    val password: String,
+
+    @Column(nullable = false)
+    val nickname: String,
+
+    @CreationTimestamp
+    val createdAt: LocalDateTime = LocalDateTime.MIN,
+
+    @UpdateTimestamp
+    val updatedAt: LocalDateTime = LocalDateTime.MIN
+) {
+    companion object {
+        fun createUser(
+            accountId: String,
+            password: String,
+            nickname: String
+        ): User {
+            return User(
+                accountId = accountId,
+                password = password,
+                nickname = nickname
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/exception/DuplicateAccountIdException.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/exception/DuplicateAccountIdException.kt
@@ -1,0 +1,15 @@
+package com.zunza.buythedip_kotlin.user.exception
+
+import com.zunza.buythedip_kotlin.common.CustomException
+import jakarta.servlet.http.HttpServletResponse
+
+class DuplicateAccountIdException : CustomException(MESSAGE) {
+
+    companion object {
+        const val MESSAGE: String = "이미 사용 중인 아이디 입니다."
+    }
+
+    override fun getStatusCode(): Int {
+        return HttpServletResponse.SC_CONFLICT
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/exception/DuplicateNicknameException.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/exception/DuplicateNicknameException.kt
@@ -1,0 +1,15 @@
+package com.zunza.buythedip_kotlin.user.exception
+
+import com.zunza.buythedip_kotlin.common.CustomException
+import jakarta.servlet.http.HttpServletResponse
+
+class DuplicateNicknameException : CustomException(MESSAGE) {
+
+    companion object {
+        const val MESSAGE: String = "이미 사용 중인 닉네임 입니다."
+    }
+
+    override fun getStatusCode(): Int {
+        return HttpServletResponse.SC_CONFLICT
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/repository/UserRepository.kt
@@ -1,0 +1,11 @@
+package com.zunza.buythedip_kotlin.user.repository
+
+import com.zunza.buythedip_kotlin.user.entity.User
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface UserRepository : JpaRepository<User, Long> {
+    fun existsByAccountId(accountId: String): Boolean
+    fun existsByNickname(nickname: String): Boolean
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/service/AuthService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/service/AuthService.kt
@@ -1,0 +1,42 @@
+package com.zunza.buythedip_kotlin.user.service
+
+import com.zunza.buythedip_kotlin.user.dto.SignupRequest
+import com.zunza.buythedip_kotlin.user.dto.ValidationRequest
+import com.zunza.buythedip_kotlin.user.dto.ValidationRequest.ValidationType.*
+import com.zunza.buythedip_kotlin.user.entity.User
+import com.zunza.buythedip_kotlin.user.exception.DuplicateAccountIdException
+import com.zunza.buythedip_kotlin.user.exception.DuplicateNicknameException
+import com.zunza.buythedip_kotlin.user.repository.UserRepository
+import org.springframework.security.crypto.password.PasswordEncoder
+import org.springframework.stereotype.Service
+
+@Service
+class AuthService(
+    private val userRepository: UserRepository,
+    private val passwordEncoder: PasswordEncoder
+) {
+    fun checkAvailability(validationRequest: ValidationRequest) {
+        when (validationRequest.validationType) {
+            ACCOUNT_ID -> checkAccountIdAvailability(validationRequest.value)
+            NICKNAME -> checkNicknameAvailability(validationRequest.value)
+        }
+    }
+
+    fun signup(signupRequest: SignupRequest) {
+        val encodedPassword: String = passwordEncoder.encode(signupRequest.password)
+        val user = User.createUser(signupRequest.accountId, encodedPassword, signupRequest.nickname)
+        userRepository.save(user)
+    }
+
+    private fun checkAccountIdAvailability(value: String) {
+        if (userRepository.existsByAccountId(value)) {
+            throw DuplicateAccountIdException()
+        }
+    }
+
+    private fun checkNicknameAvailability(value: String) {
+        if (userRepository.existsByNickname(value)) {
+            throw DuplicateNicknameException()
+        }
+    }
+}

--- a/src/main/resources/static/docs/index.html
+++ b/src/main/resources/static/docs/index.html
@@ -1,0 +1,837 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta http-equiv="X-UA-Compatible" content="IE=edge">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<meta name="generator" content="Asciidoctor 2.0.18">
+<title>User API</title>
+<link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700">
+<style>
+/*! Asciidoctor default stylesheet | MIT License | https://asciidoctor.org */
+/* Uncomment the following line when using as a custom stylesheet */
+/* @import "https://fonts.googleapis.com/css?family=Open+Sans:300,300italic,400,400italic,600,600italic%7CNoto+Serif:400,400italic,700,700italic%7CDroid+Sans+Mono:400,700"; */
+html{font-family:sans-serif;-webkit-text-size-adjust:100%}
+a{background:none}
+a:focus{outline:thin dotted}
+a:active,a:hover{outline:0}
+h1{font-size:2em;margin:.67em 0}
+b,strong{font-weight:bold}
+abbr{font-size:.9em}
+abbr[title]{cursor:help;border-bottom:1px dotted #dddddf;text-decoration:none}
+dfn{font-style:italic}
+hr{height:0}
+mark{background:#ff0;color:#000}
+code,kbd,pre,samp{font-family:monospace;font-size:1em}
+pre{white-space:pre-wrap}
+q{quotes:"\201C" "\201D" "\2018" "\2019"}
+small{font-size:80%}
+sub,sup{font-size:75%;line-height:0;position:relative;vertical-align:baseline}
+sup{top:-.5em}
+sub{bottom:-.25em}
+img{border:0}
+svg:not(:root){overflow:hidden}
+figure{margin:0}
+audio,video{display:inline-block}
+audio:not([controls]){display:none;height:0}
+fieldset{border:1px solid silver;margin:0 2px;padding:.35em .625em .75em}
+legend{border:0;padding:0}
+button,input,select,textarea{font-family:inherit;font-size:100%;margin:0}
+button,input{line-height:normal}
+button,select{text-transform:none}
+button,html input[type=button],input[type=reset],input[type=submit]{-webkit-appearance:button;cursor:pointer}
+button[disabled],html input[disabled]{cursor:default}
+input[type=checkbox],input[type=radio]{padding:0}
+button::-moz-focus-inner,input::-moz-focus-inner{border:0;padding:0}
+textarea{overflow:auto;vertical-align:top}
+table{border-collapse:collapse;border-spacing:0}
+*,::before,::after{box-sizing:border-box}
+html,body{font-size:100%}
+body{background:#fff;color:rgba(0,0,0,.8);padding:0;margin:0;font-family:"Noto Serif","DejaVu Serif",serif;line-height:1;position:relative;cursor:auto;-moz-tab-size:4;-o-tab-size:4;tab-size:4;word-wrap:anywhere;-moz-osx-font-smoothing:grayscale;-webkit-font-smoothing:antialiased}
+a:hover{cursor:pointer}
+img,object,embed{max-width:100%;height:auto}
+object,embed{height:100%}
+img{-ms-interpolation-mode:bicubic}
+.left{float:left!important}
+.right{float:right!important}
+.text-left{text-align:left!important}
+.text-right{text-align:right!important}
+.text-center{text-align:center!important}
+.text-justify{text-align:justify!important}
+.hide{display:none}
+img,object,svg{display:inline-block;vertical-align:middle}
+textarea{height:auto;min-height:50px}
+select{width:100%}
+.subheader,.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{line-height:1.45;color:#7a2518;font-weight:400;margin-top:0;margin-bottom:.25em}
+div,dl,dt,dd,ul,ol,li,h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6,pre,form,p,blockquote,th,td{margin:0;padding:0}
+a{color:#2156a5;text-decoration:underline;line-height:inherit}
+a:hover,a:focus{color:#1d4b8f}
+a img{border:0}
+p{line-height:1.6;margin-bottom:1.25em;text-rendering:optimizeLegibility}
+p aside{font-size:.875em;line-height:1.35;font-style:italic}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{font-family:"Open Sans","DejaVu Sans",sans-serif;font-weight:300;font-style:normal;color:#ba3925;text-rendering:optimizeLegibility;margin-top:1em;margin-bottom:.5em;line-height:1.0125em}
+h1 small,h2 small,h3 small,#toctitle small,.sidebarblock>.content>.title small,h4 small,h5 small,h6 small{font-size:60%;color:#e99b8f;line-height:0}
+h1{font-size:2.125em}
+h2{font-size:1.6875em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.375em}
+h4,h5{font-size:1.125em}
+h6{font-size:1em}
+hr{border:solid #dddddf;border-width:1px 0 0;clear:both;margin:1.25em 0 1.1875em}
+em,i{font-style:italic;line-height:inherit}
+strong,b{font-weight:bold;line-height:inherit}
+small{font-size:60%;line-height:inherit}
+code{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;font-weight:400;color:rgba(0,0,0,.9)}
+ul,ol,dl{line-height:1.6;margin-bottom:1.25em;list-style-position:outside;font-family:inherit}
+ul,ol{margin-left:1.5em}
+ul li ul,ul li ol{margin-left:1.25em;margin-bottom:0}
+ul.circle{list-style-type:circle}
+ul.disc{list-style-type:disc}
+ul.square{list-style-type:square}
+ul.circle ul:not([class]),ul.disc ul:not([class]),ul.square ul:not([class]){list-style:inherit}
+ol li ul,ol li ol{margin-left:1.25em;margin-bottom:0}
+dl dt{margin-bottom:.3125em;font-weight:bold}
+dl dd{margin-bottom:1.25em}
+blockquote{margin:0 0 1.25em;padding:.5625em 1.25em 0 1.1875em;border-left:1px solid #ddd}
+blockquote,blockquote p{line-height:1.6;color:rgba(0,0,0,.85)}
+@media screen and (min-width:768px){h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2}
+h1{font-size:2.75em}
+h2{font-size:2.3125em}
+h3,#toctitle,.sidebarblock>.content>.title{font-size:1.6875em}
+h4{font-size:1.4375em}}
+table{background:#fff;margin-bottom:1.25em;border:1px solid #dedede;word-wrap:normal}
+table thead,table tfoot{background:#f7f8f7}
+table thead tr th,table thead tr td,table tfoot tr th,table tfoot tr td{padding:.5em .625em .625em;font-size:inherit;color:rgba(0,0,0,.8);text-align:left}
+table tr th,table tr td{padding:.5625em .625em;font-size:inherit;color:rgba(0,0,0,.8)}
+table tr.even,table tr.alt{background:#f8f8f7}
+table thead tr th,table tfoot tr th,table tbody tr td,table tr td,table tfoot tr td{line-height:1.6}
+h1,h2,h3,#toctitle,.sidebarblock>.content>.title,h4,h5,h6{line-height:1.2;word-spacing:-.05em}
+h1 strong,h2 strong,h3 strong,#toctitle strong,.sidebarblock>.content>.title strong,h4 strong,h5 strong,h6 strong{font-weight:400}
+.center{margin-left:auto;margin-right:auto}
+.stretch{width:100%}
+.clearfix::before,.clearfix::after,.float-group::before,.float-group::after{content:" ";display:table}
+.clearfix::after,.float-group::after{clear:both}
+:not(pre).nobreak{word-wrap:normal}
+:not(pre).nowrap{white-space:nowrap}
+:not(pre).pre-wrap{white-space:pre-wrap}
+:not(pre):not([class^=L])>code{font-size:.9375em;font-style:normal!important;letter-spacing:0;padding:.1em .5ex;word-spacing:-.15em;background:#f7f7f8;border-radius:4px;line-height:1.45;text-rendering:optimizeSpeed}
+pre{color:rgba(0,0,0,.9);font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;line-height:1.45;text-rendering:optimizeSpeed}
+pre code,pre pre{color:inherit;font-size:inherit;line-height:inherit}
+pre>code{display:block}
+pre.nowrap,pre.nowrap pre{white-space:pre;word-wrap:normal}
+em em{font-style:normal}
+strong strong{font-weight:400}
+.keyseq{color:rgba(51,51,51,.8)}
+kbd{font-family:"Droid Sans Mono","DejaVu Sans Mono",monospace;display:inline-block;color:rgba(0,0,0,.8);font-size:.65em;line-height:1.45;background:#f7f7f7;border:1px solid #ccc;border-radius:3px;box-shadow:0 1px 0 rgba(0,0,0,.2),inset 0 0 0 .1em #fff;margin:0 .15em;padding:.2em .5em;vertical-align:middle;position:relative;top:-.1em;white-space:nowrap}
+.keyseq kbd:first-child{margin-left:0}
+.keyseq kbd:last-child{margin-right:0}
+.menuseq,.menuref{color:#000}
+.menuseq b:not(.caret),.menuref{font-weight:inherit}
+.menuseq{word-spacing:-.02em}
+.menuseq b.caret{font-size:1.25em;line-height:.8}
+.menuseq i.caret{font-weight:bold;text-align:center;width:.45em}
+b.button::before,b.button::after{position:relative;top:-1px;font-weight:400}
+b.button::before{content:"[";padding:0 3px 0 2px}
+b.button::after{content:"]";padding:0 2px 0 3px}
+p a>code:hover{color:rgba(0,0,0,.9)}
+#header,#content,#footnotes,#footer{width:100%;margin:0 auto;max-width:62.5em;*zoom:1;position:relative;padding-left:.9375em;padding-right:.9375em}
+#header::before,#header::after,#content::before,#content::after,#footnotes::before,#footnotes::after,#footer::before,#footer::after{content:" ";display:table}
+#header::after,#content::after,#footnotes::after,#footer::after{clear:both}
+#content{margin-top:1.25em}
+#content::before{content:none}
+#header>h1:first-child{color:rgba(0,0,0,.85);margin-top:2.25rem;margin-bottom:0}
+#header>h1:first-child+#toc{margin-top:8px;border-top:1px solid #dddddf}
+#header>h1:only-child,body.toc2 #header>h1:nth-last-child(2){border-bottom:1px solid #dddddf;padding-bottom:8px}
+#header .details{border-bottom:1px solid #dddddf;line-height:1.45;padding-top:.25em;padding-bottom:.25em;padding-left:.25em;color:rgba(0,0,0,.6);display:flex;flex-flow:row wrap}
+#header .details span:first-child{margin-left:-.125em}
+#header .details span.email a{color:rgba(0,0,0,.85)}
+#header .details br{display:none}
+#header .details br+span::before{content:"\00a0\2013\00a0"}
+#header .details br+span.author::before{content:"\00a0\22c5\00a0";color:rgba(0,0,0,.85)}
+#header .details br+span#revremark::before{content:"\00a0|\00a0"}
+#header #revnumber{text-transform:capitalize}
+#header #revnumber::after{content:"\00a0"}
+#content>h1:first-child:not([class]){color:rgba(0,0,0,.85);border-bottom:1px solid #dddddf;padding-bottom:8px;margin-top:0;padding-top:1rem;margin-bottom:1.25rem}
+#toc{border-bottom:1px solid #e7e7e9;padding-bottom:.5em}
+#toc>ul{margin-left:.125em}
+#toc ul.sectlevel0>li>a{font-style:italic}
+#toc ul.sectlevel0 ul.sectlevel1{margin:.5em 0}
+#toc ul{font-family:"Open Sans","DejaVu Sans",sans-serif;list-style-type:none}
+#toc li{line-height:1.3334;margin-top:.3334em}
+#toc a{text-decoration:none}
+#toc a:active{text-decoration:underline}
+#toctitle{color:#7a2518;font-size:1.2em}
+@media screen and (min-width:768px){#toctitle{font-size:1.375em}
+body.toc2{padding-left:15em;padding-right:0}
+#toc.toc2{margin-top:0!important;background:#f8f8f7;position:fixed;width:15em;left:0;top:0;border-right:1px solid #e7e7e9;border-top-width:0!important;border-bottom-width:0!important;z-index:1000;padding:1.25em 1em;height:100%;overflow:auto}
+#toc.toc2 #toctitle{margin-top:0;margin-bottom:.8rem;font-size:1.2em}
+#toc.toc2>ul{font-size:.9em;margin-bottom:0}
+#toc.toc2 ul ul{margin-left:0;padding-left:1em}
+#toc.toc2 ul.sectlevel0 ul.sectlevel1{padding-left:0;margin-top:.5em;margin-bottom:.5em}
+body.toc2.toc-right{padding-left:0;padding-right:15em}
+body.toc2.toc-right #toc.toc2{border-right-width:0;border-left:1px solid #e7e7e9;left:auto;right:0}}
+@media screen and (min-width:1280px){body.toc2{padding-left:20em;padding-right:0}
+#toc.toc2{width:20em}
+#toc.toc2 #toctitle{font-size:1.375em}
+#toc.toc2>ul{font-size:.95em}
+#toc.toc2 ul ul{padding-left:1.25em}
+body.toc2.toc-right{padding-left:0;padding-right:20em}}
+#content #toc{border:1px solid #e0e0dc;margin-bottom:1.25em;padding:1.25em;background:#f8f8f7;border-radius:4px}
+#content #toc>:first-child{margin-top:0}
+#content #toc>:last-child{margin-bottom:0}
+#footer{max-width:none;background:rgba(0,0,0,.8);padding:1.25em}
+#footer-text{color:hsla(0,0%,100%,.8);line-height:1.44}
+#content{margin-bottom:.625em}
+.sect1{padding-bottom:.625em}
+@media screen and (min-width:768px){#content{margin-bottom:1.25em}
+.sect1{padding-bottom:1.25em}}
+.sect1:last-child{padding-bottom:0}
+.sect1+.sect1{border-top:1px solid #e7e7e9}
+#content h1>a.anchor,h2>a.anchor,h3>a.anchor,#toctitle>a.anchor,.sidebarblock>.content>.title>a.anchor,h4>a.anchor,h5>a.anchor,h6>a.anchor{position:absolute;z-index:1001;width:1.5ex;margin-left:-1.5ex;display:block;text-decoration:none!important;visibility:hidden;text-align:center;font-weight:400}
+#content h1>a.anchor::before,h2>a.anchor::before,h3>a.anchor::before,#toctitle>a.anchor::before,.sidebarblock>.content>.title>a.anchor::before,h4>a.anchor::before,h5>a.anchor::before,h6>a.anchor::before{content:"\00A7";font-size:.85em;display:block;padding-top:.1em}
+#content h1:hover>a.anchor,#content h1>a.anchor:hover,h2:hover>a.anchor,h2>a.anchor:hover,h3:hover>a.anchor,#toctitle:hover>a.anchor,.sidebarblock>.content>.title:hover>a.anchor,h3>a.anchor:hover,#toctitle>a.anchor:hover,.sidebarblock>.content>.title>a.anchor:hover,h4:hover>a.anchor,h4>a.anchor:hover,h5:hover>a.anchor,h5>a.anchor:hover,h6:hover>a.anchor,h6>a.anchor:hover{visibility:visible}
+#content h1>a.link,h2>a.link,h3>a.link,#toctitle>a.link,.sidebarblock>.content>.title>a.link,h4>a.link,h5>a.link,h6>a.link{color:#ba3925;text-decoration:none}
+#content h1>a.link:hover,h2>a.link:hover,h3>a.link:hover,#toctitle>a.link:hover,.sidebarblock>.content>.title>a.link:hover,h4>a.link:hover,h5>a.link:hover,h6>a.link:hover{color:#a53221}
+details,.audioblock,.imageblock,.literalblock,.listingblock,.stemblock,.videoblock{margin-bottom:1.25em}
+details{margin-left:1.25rem}
+details>summary{cursor:pointer;display:block;position:relative;line-height:1.6;margin-bottom:.625rem;outline:none;-webkit-tap-highlight-color:transparent}
+details>summary::-webkit-details-marker{display:none}
+details>summary::before{content:"";border:solid transparent;border-left:solid;border-width:.3em 0 .3em .5em;position:absolute;top:.5em;left:-1.25rem;transform:translateX(15%)}
+details[open]>summary::before{border:solid transparent;border-top:solid;border-width:.5em .3em 0;transform:translateY(15%)}
+details>summary::after{content:"";width:1.25rem;height:1em;position:absolute;top:.3em;left:-1.25rem}
+.admonitionblock td.content>.title,.audioblock>.title,.exampleblock>.title,.imageblock>.title,.listingblock>.title,.literalblock>.title,.stemblock>.title,.openblock>.title,.paragraph>.title,.quoteblock>.title,table.tableblock>.title,.verseblock>.title,.videoblock>.title,.dlist>.title,.olist>.title,.ulist>.title,.qlist>.title,.hdlist>.title{text-rendering:optimizeLegibility;text-align:left;font-family:"Noto Serif","DejaVu Serif",serif;font-size:1rem;font-style:italic}
+table.tableblock.fit-content>caption.title{white-space:nowrap;width:0}
+.paragraph.lead>p,#preamble>.sectionbody>[class=paragraph]:first-of-type p{font-size:1.21875em;line-height:1.6;color:rgba(0,0,0,.85)}
+.admonitionblock>table{border-collapse:separate;border:0;background:none;width:100%}
+.admonitionblock>table td.icon{text-align:center;width:80px}
+.admonitionblock>table td.icon img{max-width:none}
+.admonitionblock>table td.icon .title{font-weight:bold;font-family:"Open Sans","DejaVu Sans",sans-serif;text-transform:uppercase}
+.admonitionblock>table td.content{padding-left:1.125em;padding-right:1.25em;border-left:1px solid #dddddf;color:rgba(0,0,0,.6);word-wrap:anywhere}
+.admonitionblock>table td.content>:last-child>:last-child{margin-bottom:0}
+.exampleblock>.content{border:1px solid #e6e6e6;margin-bottom:1.25em;padding:1.25em;background:#fff;border-radius:4px}
+.exampleblock>.content>:first-child{margin-top:0}
+.exampleblock>.content>:last-child{margin-bottom:0}
+.sidebarblock{border:1px solid #dbdbd6;margin-bottom:1.25em;padding:1.25em;background:#f3f3f2;border-radius:4px}
+.sidebarblock>:first-child{margin-top:0}
+.sidebarblock>:last-child{margin-bottom:0}
+.sidebarblock>.content>.title{color:#7a2518;margin-top:0;text-align:center}
+.exampleblock>.content>:last-child>:last-child,.exampleblock>.content .olist>ol>li:last-child>:last-child,.exampleblock>.content .ulist>ul>li:last-child>:last-child,.exampleblock>.content .qlist>ol>li:last-child>:last-child,.sidebarblock>.content>:last-child>:last-child,.sidebarblock>.content .olist>ol>li:last-child>:last-child,.sidebarblock>.content .ulist>ul>li:last-child>:last-child,.sidebarblock>.content .qlist>ol>li:last-child>:last-child{margin-bottom:0}
+.literalblock pre,.listingblock>.content>pre{border-radius:4px;overflow-x:auto;padding:1em;font-size:.8125em}
+@media screen and (min-width:768px){.literalblock pre,.listingblock>.content>pre{font-size:.90625em}}
+@media screen and (min-width:1280px){.literalblock pre,.listingblock>.content>pre{font-size:1em}}
+.literalblock pre,.listingblock>.content>pre:not(.highlight),.listingblock>.content>pre[class=highlight],.listingblock>.content>pre[class^="highlight "]{background:#f7f7f8}
+.literalblock.output pre{color:#f7f7f8;background:rgba(0,0,0,.9)}
+.listingblock>.content{position:relative}
+.listingblock code[data-lang]::before{display:none;content:attr(data-lang);position:absolute;font-size:.75em;top:.425rem;right:.5rem;line-height:1;text-transform:uppercase;color:inherit;opacity:.5}
+.listingblock:hover code[data-lang]::before{display:block}
+.listingblock.terminal pre .command::before{content:attr(data-prompt);padding-right:.5em;color:inherit;opacity:.5}
+.listingblock.terminal pre .command:not([data-prompt])::before{content:"$"}
+.listingblock pre.highlightjs{padding:0}
+.listingblock pre.highlightjs>code{padding:1em;border-radius:4px}
+.listingblock pre.prettyprint{border-width:0}
+.prettyprint{background:#f7f7f8}
+pre.prettyprint .linenums{line-height:1.45;margin-left:2em}
+pre.prettyprint li{background:none;list-style-type:inherit;padding-left:0}
+pre.prettyprint li code[data-lang]::before{opacity:1}
+pre.prettyprint li:not(:first-child) code[data-lang]::before{display:none}
+table.linenotable{border-collapse:separate;border:0;margin-bottom:0;background:none}
+table.linenotable td[class]{color:inherit;vertical-align:top;padding:0;line-height:inherit;white-space:normal}
+table.linenotable td.code{padding-left:.75em}
+table.linenotable td.linenos,pre.pygments .linenos{border-right:1px solid;opacity:.35;padding-right:.5em;-webkit-user-select:none;-moz-user-select:none;-ms-user-select:none;user-select:none}
+pre.pygments span.linenos{display:inline-block;margin-right:.75em}
+.quoteblock{margin:0 1em 1.25em 1.5em;display:table}
+.quoteblock:not(.excerpt)>.title{margin-left:-1.5em;margin-bottom:.75em}
+.quoteblock blockquote,.quoteblock p{color:rgba(0,0,0,.85);font-size:1.15rem;line-height:1.75;word-spacing:.1em;letter-spacing:0;font-style:italic;text-align:justify}
+.quoteblock blockquote{margin:0;padding:0;border:0}
+.quoteblock blockquote::before{content:"\201c";float:left;font-size:2.75em;font-weight:bold;line-height:.6em;margin-left:-.6em;color:#7a2518;text-shadow:0 1px 2px rgba(0,0,0,.1)}
+.quoteblock blockquote>.paragraph:last-child p{margin-bottom:0}
+.quoteblock .attribution{margin-top:.75em;margin-right:.5ex;text-align:right}
+.verseblock{margin:0 1em 1.25em}
+.verseblock pre{font-family:"Open Sans","DejaVu Sans",sans-serif;font-size:1.15rem;color:rgba(0,0,0,.85);font-weight:300;text-rendering:optimizeLegibility}
+.verseblock pre strong{font-weight:400}
+.verseblock .attribution{margin-top:1.25rem;margin-left:.5ex}
+.quoteblock .attribution,.verseblock .attribution{font-size:.9375em;line-height:1.45;font-style:italic}
+.quoteblock .attribution br,.verseblock .attribution br{display:none}
+.quoteblock .attribution cite,.verseblock .attribution cite{display:block;letter-spacing:-.025em;color:rgba(0,0,0,.6)}
+.quoteblock.abstract blockquote::before,.quoteblock.excerpt blockquote::before,.quoteblock .quoteblock blockquote::before{display:none}
+.quoteblock.abstract blockquote,.quoteblock.abstract p,.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{line-height:1.6;word-spacing:0}
+.quoteblock.abstract{margin:0 1em 1.25em;display:block}
+.quoteblock.abstract>.title{margin:0 0 .375em;font-size:1.15em;text-align:center}
+.quoteblock.excerpt>blockquote,.quoteblock .quoteblock{padding:0 0 .25em 1em;border-left:.25em solid #dddddf}
+.quoteblock.excerpt,.quoteblock .quoteblock{margin-left:0}
+.quoteblock.excerpt blockquote,.quoteblock.excerpt p,.quoteblock .quoteblock blockquote,.quoteblock .quoteblock p{color:inherit;font-size:1.0625rem}
+.quoteblock.excerpt .attribution,.quoteblock .quoteblock .attribution{color:inherit;font-size:.85rem;text-align:left;margin-right:0}
+p.tableblock:last-child{margin-bottom:0}
+td.tableblock>.content{margin-bottom:1.25em;word-wrap:anywhere}
+td.tableblock>.content>:last-child{margin-bottom:-1.25em}
+table.tableblock,th.tableblock,td.tableblock{border:0 solid #dedede}
+table.grid-all>*>tr>*{border-width:1px}
+table.grid-cols>*>tr>*{border-width:0 1px}
+table.grid-rows>*>tr>*{border-width:1px 0}
+table.frame-all{border-width:1px}
+table.frame-ends{border-width:1px 0}
+table.frame-sides{border-width:0 1px}
+table.frame-none>colgroup+*>:first-child>*,table.frame-sides>colgroup+*>:first-child>*{border-top-width:0}
+table.frame-none>:last-child>:last-child>*,table.frame-sides>:last-child>:last-child>*{border-bottom-width:0}
+table.frame-none>*>tr>:first-child,table.frame-ends>*>tr>:first-child{border-left-width:0}
+table.frame-none>*>tr>:last-child,table.frame-ends>*>tr>:last-child{border-right-width:0}
+table.stripes-all>*>tr,table.stripes-odd>*>tr:nth-of-type(odd),table.stripes-even>*>tr:nth-of-type(even),table.stripes-hover>*>tr:hover{background:#f8f8f7}
+th.halign-left,td.halign-left{text-align:left}
+th.halign-right,td.halign-right{text-align:right}
+th.halign-center,td.halign-center{text-align:center}
+th.valign-top,td.valign-top{vertical-align:top}
+th.valign-bottom,td.valign-bottom{vertical-align:bottom}
+th.valign-middle,td.valign-middle{vertical-align:middle}
+table thead th,table tfoot th{font-weight:bold}
+tbody tr th{background:#f7f8f7}
+tbody tr th,tbody tr th p,tfoot tr th,tfoot tr th p{color:rgba(0,0,0,.8);font-weight:bold}
+p.tableblock>code:only-child{background:none;padding:0}
+p.tableblock{font-size:1em}
+ol{margin-left:1.75em}
+ul li ol{margin-left:1.5em}
+dl dd{margin-left:1.125em}
+dl dd:last-child,dl dd:last-child>:last-child{margin-bottom:0}
+li p,ul dd,ol dd,.olist .olist,.ulist .ulist,.ulist .olist,.olist .ulist{margin-bottom:.625em}
+ul.checklist,ul.none,ol.none,ul.no-bullet,ol.no-bullet,ol.unnumbered,ul.unstyled,ol.unstyled{list-style-type:none}
+ul.no-bullet,ol.no-bullet,ol.unnumbered{margin-left:.625em}
+ul.unstyled,ol.unstyled{margin-left:0}
+li>p:empty:only-child::before{content:"";display:inline-block}
+ul.checklist>li>p:first-child{margin-left:-1em}
+ul.checklist>li>p:first-child>.fa-square-o:first-child,ul.checklist>li>p:first-child>.fa-check-square-o:first-child{width:1.25em;font-size:.8em;position:relative;bottom:.125em}
+ul.checklist>li>p:first-child>input[type=checkbox]:first-child{margin-right:.25em}
+ul.inline{display:flex;flex-flow:row wrap;list-style:none;margin:0 0 .625em -1.25em}
+ul.inline>li{margin-left:1.25em}
+.unstyled dl dt{font-weight:400;font-style:normal}
+ol.arabic{list-style-type:decimal}
+ol.decimal{list-style-type:decimal-leading-zero}
+ol.loweralpha{list-style-type:lower-alpha}
+ol.upperalpha{list-style-type:upper-alpha}
+ol.lowerroman{list-style-type:lower-roman}
+ol.upperroman{list-style-type:upper-roman}
+ol.lowergreek{list-style-type:lower-greek}
+.hdlist>table,.colist>table{border:0;background:none}
+.hdlist>table>tbody>tr,.colist>table>tbody>tr{background:none}
+td.hdlist1,td.hdlist2{vertical-align:top;padding:0 .625em}
+td.hdlist1{font-weight:bold;padding-bottom:1.25em}
+td.hdlist2{word-wrap:anywhere}
+.literalblock+.colist,.listingblock+.colist{margin-top:-.5em}
+.colist td:not([class]):first-child{padding:.4em .75em 0;line-height:1;vertical-align:top}
+.colist td:not([class]):first-child img{max-width:none}
+.colist td:not([class]):last-child{padding:.25em 0}
+.thumb,.th{line-height:0;display:inline-block;border:4px solid #fff;box-shadow:0 0 0 1px #ddd}
+.imageblock.left{margin:.25em .625em 1.25em 0}
+.imageblock.right{margin:.25em 0 1.25em .625em}
+.imageblock>.title{margin-bottom:0}
+.imageblock.thumb,.imageblock.th{border-width:6px}
+.imageblock.thumb>.title,.imageblock.th>.title{padding:0 .125em}
+.image.left,.image.right{margin-top:.25em;margin-bottom:.25em;display:inline-block;line-height:0}
+.image.left{margin-right:.625em}
+.image.right{margin-left:.625em}
+a.image{text-decoration:none;display:inline-block}
+a.image object{pointer-events:none}
+sup.footnote,sup.footnoteref{font-size:.875em;position:static;vertical-align:super}
+sup.footnote a,sup.footnoteref a{text-decoration:none}
+sup.footnote a:active,sup.footnoteref a:active{text-decoration:underline}
+#footnotes{padding-top:.75em;padding-bottom:.75em;margin-bottom:.625em}
+#footnotes hr{width:20%;min-width:6.25em;margin:-.25em 0 .75em;border-width:1px 0 0}
+#footnotes .footnote{padding:0 .375em 0 .225em;line-height:1.3334;font-size:.875em;margin-left:1.2em;margin-bottom:.2em}
+#footnotes .footnote a:first-of-type{font-weight:bold;text-decoration:none;margin-left:-1.05em}
+#footnotes .footnote:last-of-type{margin-bottom:0}
+#content #footnotes{margin-top:-.625em;margin-bottom:0;padding:.75em 0}
+div.unbreakable{page-break-inside:avoid}
+.big{font-size:larger}
+.small{font-size:smaller}
+.underline{text-decoration:underline}
+.overline{text-decoration:overline}
+.line-through{text-decoration:line-through}
+.aqua{color:#00bfbf}
+.aqua-background{background:#00fafa}
+.black{color:#000}
+.black-background{background:#000}
+.blue{color:#0000bf}
+.blue-background{background:#0000fa}
+.fuchsia{color:#bf00bf}
+.fuchsia-background{background:#fa00fa}
+.gray{color:#606060}
+.gray-background{background:#7d7d7d}
+.green{color:#006000}
+.green-background{background:#007d00}
+.lime{color:#00bf00}
+.lime-background{background:#00fa00}
+.maroon{color:#600000}
+.maroon-background{background:#7d0000}
+.navy{color:#000060}
+.navy-background{background:#00007d}
+.olive{color:#606000}
+.olive-background{background:#7d7d00}
+.purple{color:#600060}
+.purple-background{background:#7d007d}
+.red{color:#bf0000}
+.red-background{background:#fa0000}
+.silver{color:#909090}
+.silver-background{background:#bcbcbc}
+.teal{color:#006060}
+.teal-background{background:#007d7d}
+.white{color:#bfbfbf}
+.white-background{background:#fafafa}
+.yellow{color:#bfbf00}
+.yellow-background{background:#fafa00}
+span.icon>.fa{cursor:default}
+a span.icon>.fa{cursor:inherit}
+.admonitionblock td.icon [class^="fa icon-"]{font-size:2.5em;text-shadow:1px 1px 2px rgba(0,0,0,.5);cursor:default}
+.admonitionblock td.icon .icon-note::before{content:"\f05a";color:#19407c}
+.admonitionblock td.icon .icon-tip::before{content:"\f0eb";text-shadow:1px 1px 2px rgba(155,155,0,.8);color:#111}
+.admonitionblock td.icon .icon-warning::before{content:"\f071";color:#bf6900}
+.admonitionblock td.icon .icon-caution::before{content:"\f06d";color:#bf3400}
+.admonitionblock td.icon .icon-important::before{content:"\f06a";color:#bf0000}
+.conum[data-value]{display:inline-block;color:#fff!important;background:rgba(0,0,0,.8);border-radius:50%;text-align:center;font-size:.75em;width:1.67em;height:1.67em;line-height:1.67em;font-family:"Open Sans","DejaVu Sans",sans-serif;font-style:normal;font-weight:bold}
+.conum[data-value] *{color:#fff!important}
+.conum[data-value]+b{display:none}
+.conum[data-value]::after{content:attr(data-value)}
+pre .conum[data-value]{position:relative;top:-.125em}
+b.conum *{color:inherit!important}
+.conum:not([data-value]):empty{display:none}
+dt,th.tableblock,td.content,div.footnote{text-rendering:optimizeLegibility}
+h1,h2,p,td.content,span.alt,summary{letter-spacing:-.01em}
+p strong,td.content strong,div.footnote strong{letter-spacing:-.005em}
+p,blockquote,dt,td.content,span.alt,summary{font-size:1.0625rem}
+p{margin-bottom:1.25rem}
+.sidebarblock p,.sidebarblock dt,.sidebarblock td.content,p.tableblock{font-size:1em}
+.exampleblock>.content{background:#fffef7;border-color:#e0e0dc;box-shadow:0 1px 4px #e0e0dc}
+.print-only{display:none!important}
+@page{margin:1.25cm .75cm}
+@media print{*{box-shadow:none!important;text-shadow:none!important}
+html{font-size:80%}
+a{color:inherit!important;text-decoration:underline!important}
+a.bare,a[href^="#"],a[href^="mailto:"]{text-decoration:none!important}
+a[href^="http:"]:not(.bare)::after,a[href^="https:"]:not(.bare)::after{content:"(" attr(href) ")";display:inline-block;font-size:.875em;padding-left:.25em}
+abbr[title]{border-bottom:1px dotted}
+abbr[title]::after{content:" (" attr(title) ")"}
+pre,blockquote,tr,img,object,svg{page-break-inside:avoid}
+thead{display:table-header-group}
+svg{max-width:100%}
+p,blockquote,dt,td.content{font-size:1em;orphans:3;widows:3}
+h2,h3,#toctitle,.sidebarblock>.content>.title{page-break-after:avoid}
+#header,#content,#footnotes,#footer{max-width:none}
+#toc,.sidebarblock,.exampleblock>.content{background:none!important}
+#toc{border-bottom:1px solid #dddddf!important;padding-bottom:0!important}
+body.book #header{text-align:center}
+body.book #header>h1:first-child{border:0!important;margin:2.5em 0 1em}
+body.book #header .details{border:0!important;display:block;padding:0!important}
+body.book #header .details span:first-child{margin-left:0!important}
+body.book #header .details br{display:block}
+body.book #header .details br+span::before{content:none!important}
+body.book #toc{border:0!important;text-align:left!important;padding:0!important;margin:0!important}
+body.book #toc,body.book #preamble,body.book h1.sect0,body.book .sect1>h2{page-break-before:always}
+.listingblock code[data-lang]::before{display:block}
+#footer{padding:0 .9375em}
+.hide-on-print{display:none!important}
+.print-only{display:block!important}
+.hide-for-print{display:none!important}
+.show-for-print{display:inherit!important}}
+@media amzn-kf8,print{#header>h1:first-child{margin-top:1.25rem}
+.sect1{padding:0!important}
+.sect1+.sect1{border:0}
+#footer{background:none}
+#footer-text{color:rgba(0,0,0,.6);font-size:.9em}}
+@media amzn-kf8{#header,#content,#footnotes,#footer{padding:0}}
+</style>
+</head>
+<body class="article toc2 toc-left">
+<div id="header">
+<div id="toc" class="toc2">
+<div id="toctitle">Table of Contents</div>
+<ul class="sectlevel1">
+<li><a href="#_user_api">User API</a>
+<ul class="sectlevel2">
+<li><a href="#_회원가입_시_계정_id_중복_체크_성공">회원가입 시 계정 ID 중복 체크 - 성공</a></li>
+<li><a href="#_회원가입_시_계정_id_중복_실패">회원가입 시 계정 ID 중복 - 실패</a></li>
+<li><a href="#_회원가입_시_닉네임_중복_체크_성공">회원가입 시 닉네임 중복 체크 - 성공</a></li>
+<li><a href="#_회원가입_시_닉네임_중복_체크_실패">회원가입 시 닉네임 중복 체크 - 실패</a></li>
+</ul>
+</li>
+</ul>
+</div>
+</div>
+<div id="content">
+<script>
+document.addEventListener('DOMContentLoaded', function() {
+    const toc = document.getElementById('toc');
+    if (toc) {
+        const lists = toc.querySelectorAll('ul ul');
+        lists.forEach(function(ul) {
+            ul.style.display = 'none';
+            const parentLi = ul.parentElement;
+            if (parentLi && parentLi.querySelector('a')) {
+                const btn = document.createElement('span');
+                btn.textContent = ' [+] ';
+                btn.style.cursor = 'pointer';
+                btn.style.color = '#06c';
+                btn.addEventListener('click', function(e) {
+                    e.stopPropagation();
+                    if (ul.style.display === 'none') {
+                        ul.style.display = '';
+                        btn.textContent = ' [-] ';
+                    } else {
+                        ul.style.display = 'none';
+                        btn.textContent = ' [+] ';
+                    }
+                });
+                parentLi.insertBefore(btn, parentLi.firstChild);
+            }
+        });
+    }
+});
+</script>
+<div class="sect1">
+<h2 id="_user_api">User API</h2>
+<div class="sectionbody">
+<div class="sect2">
+<h3 id="_회원가입_시_계정_id_중복_체크_성공">회원가입 시 계정 ID 중복 체크 - 성공</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/auth/validation/check-availability HTTP/1.1
+Content-Type: application/json
+Content-Length: 67
+Host: localhost:8080
+
+{
+  "validationType" : "accountId",
+  "value" : "not_existing_id"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>validationType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검사 유형 (ACCOUNT_ID or NICKNAME)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>value</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검사 대상 값</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 38
+
+{
+  "code" : 200,
+  "success" : true
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>success</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_회원가입_시_계정_id_중복_실패">회원가입 시 계정 ID 중복 - 실패</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/auth/validation/check-availability HTTP/1.1
+Content-Type: application/json
+Content-Length: 63
+Host: localhost:8080
+
+{
+  "validationType" : "accountId",
+  "value" : "existing_id"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>validationType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검사 유형 (ACCOUNT_ID)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>value</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검사 대상 값</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 409 Conflict
+Content-Type: application/json
+Content-Length: 117
+
+{
+  "data" : {
+    "message" : "이미 사용 중인 아이디 입니다."
+  },
+  "code" : 409,
+  "success" : false
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>success</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+<div class="sect2">
+<h3 id="_회원가입_시_닉네임_중복_체크_성공">회원가입 시 닉네임 중복 체크 - 성공</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/auth/validation/check-availability HTTP/1.1
+Content-Type: application/json
+Content-Length: 72
+Host: localhost:8080
+
+{
+  "validationType" : "nickname",
+  "value" : "not_existing_nickname"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>validationType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검사 유형 (NICKNAME)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>value</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검사 대상 값</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 200 OK
+Content-Type: application/json
+Content-Length: 38
+
+{
+  "code" : 200,
+  "success" : true
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>success</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+</tbody>
+</table>
+<div class="paragraph">
+<p></p>
+</div>
+</div>
+<div class="sect2">
+<h3 id="_회원가입_시_닉네임_중복_체크_실패">회원가입 시 닉네임 중복 체크 - 실패</h3>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">POST /api/auth/validation/check-availability HTTP/1.1
+Content-Type: application/json
+Content-Length: 68
+Host: localhost:8080
+
+{
+  "validationType" : "nickname",
+  "value" : "existing_nickname"
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>validationType</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검사 유형 (NICKNAME)</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>value</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">검사 대상 값</p></td>
+</tr>
+</tbody>
+</table>
+<div class="listingblock">
+<div class="content">
+<pre class="highlight nowrap"><code class="language-http" data-lang="http">HTTP/1.1 409 Conflict
+Content-Type: application/json
+Content-Length: 117
+
+{
+  "data" : {
+    "message" : "이미 사용 중인 닉네임 입니다."
+  },
+  "code" : 409,
+  "success" : false
+}</code></pre>
+</div>
+</div>
+<table class="tableblock frame-all grid-all stretch">
+<colgroup>
+<col style="width: 33.3333%;">
+<col style="width: 33.3333%;">
+<col style="width: 33.3334%;">
+</colgroup>
+<thead>
+<tr>
+<th class="tableblock halign-left valign-top">Path</th>
+<th class="tableblock halign-left valign-top">Type</th>
+<th class="tableblock halign-left valign-top">Description</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>data.message</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>String</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">에러 메시지</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>code</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Number</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">응답 코드</p></td>
+</tr>
+<tr>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>success</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock"><code>Boolean</code></p></td>
+<td class="tableblock halign-left valign-top"><p class="tableblock">성공 여부</p></td>
+</tr>
+</tbody>
+</table>
+</div>
+</div>
+</div>
+</div>
+<div id="footer">
+<div id="footer-text">
+Version 0.0.1-SNAPSHOT<br>
+Last updated 2025-07-28 21:48:10 +0900
+</div>
+</div>
+</body>
+</html>

--- a/src/test/kotlin/com/zunza/buythedip_kotlin/BuythedipKotlinApplicationTests.kt
+++ b/src/test/kotlin/com/zunza/buythedip_kotlin/BuythedipKotlinApplicationTests.kt
@@ -1,0 +1,13 @@
+package com.zunza.buythedip_kotlin
+
+import org.junit.jupiter.api.Test
+import org.springframework.boot.test.context.SpringBootTest
+
+@SpringBootTest
+class BuythedipKotlinApplicationTests {
+
+	@Test
+	fun contextLoads() {
+	}
+
+}

--- a/src/test/kotlin/com/zunza/buythedip_kotlin/user/controller/AuthControllerCheckAvailabilityTest.kt
+++ b/src/test/kotlin/com/zunza/buythedip_kotlin/user/controller/AuthControllerCheckAvailabilityTest.kt
@@ -1,0 +1,174 @@
+package com.zunza.buythedip_kotlin.user.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.zunza.buythedip_kotlin.config.SecurityConfig
+import com.zunza.buythedip_kotlin.user.dto.ValidationRequest
+import com.zunza.buythedip_kotlin.user.exception.DuplicateAccountIdException
+import com.zunza.buythedip_kotlin.user.exception.DuplicateNicknameException
+import com.zunza.buythedip_kotlin.user.service.AuthService
+import com.zunza.buythedip_kotlin.util.restDocMockMvcBuild
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.restdocs.ManualRestDocumentation
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.test.web.servlet.post
+import org.springframework.web.context.WebApplicationContext
+
+
+@Import(SecurityConfig::class)
+@WebMvcTest(AuthController::class)
+class AuthControllerCheckAvailabilityTest(
+    @MockkBean private val authService: AuthService,
+    @Autowired private val objectMapper: ObjectMapper,
+    @Autowired private val context: WebApplicationContext
+) : BehaviorSpec({
+
+    val restDocumentation = ManualRestDocumentation()
+    val mockMvc = restDocMockMvcBuild(context, restDocumentation)
+
+    beforeEach { restDocumentation.beforeTest(javaClass, it.name.testName) }
+    afterEach { restDocumentation.afterTest() }
+
+    Given("회원가입 시 중복체크 요청을 받았을 때") {
+        val url = "/api/auth/validation/check-availability"
+
+        When("유효한 accountId 라면") {
+            val request = ValidationRequest(ValidationRequest.ValidationType.ACCOUNT_ID, "not_existing_id")
+            every { authService.checkAvailability(request) } returns Unit
+
+            Then("200 OK, 요청 성공여부(true)를 응답한다.") {
+                mockMvc.post(url) {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(request)
+                }
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.code") { value(200) }
+                    jsonPath("$.success") { value(true) }
+                }
+                .andDo {
+                    handle (
+                        document(
+                            "auth-check-availability-conflict-account-id-success",
+                            requestFields(
+                                fieldWithPath("validationType").description("검사 유형 (ACCOUNT_ID or NICKNAME)"),
+                                fieldWithPath("value").description("검사 대상 값")
+                            ),
+                            responseFields(
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("success").description("성공 여부")
+                            )
+                        )
+                    )
+                }
+            }
+        }
+
+        When("accountId가 이미 존재한다면") {
+            val request = ValidationRequest(ValidationRequest.ValidationType.ACCOUNT_ID, "existing_id")
+            every { authService.checkAvailability(request) } throws DuplicateAccountIdException()
+            Then("에러 메시지, 409 Conflict, 요청 성공여부(false)를 응답한다.") {
+                mockMvc.post(url) {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(request)
+                }
+                .andExpect {
+                    status { isConflict() }
+                    jsonPath("$.data.message") { value("이미 사용 중인 아이디 입니다.") }
+                    jsonPath("$.code") { value(409) }
+                    jsonPath("$.success") { value(false) }
+                }
+                .andDo {
+                    handle(
+                        document(
+                            "auth-check-availability-conflict-account-id-fail",
+                            requestFields(
+                                fieldWithPath("validationType").description("검사 유형 (ACCOUNT_ID)"),
+                                fieldWithPath("value").description("검사 대상 값")
+                            ),
+                            responseFields(
+                                fieldWithPath("data.message").description("에러 메시지"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("success").description("성공 여부")
+                            )
+                        )
+                    )
+                }
+            }
+        }
+
+        When("유효한 Nickname 이라면") {
+            val request = ValidationRequest(ValidationRequest.ValidationType.NICKNAME, "not_existing_nickname")
+            every { authService.checkAvailability(request) } returns Unit
+
+            Then("200 OK, 요청 성공여부(true)를 응답한다.") {
+                mockMvc.post(url) {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(request)
+                }
+                .andExpect {
+                    status { isOk() }
+                    jsonPath("$.code") { value(200) }
+                    jsonPath("$.success") { value(true) }
+                }
+                .andDo {
+                    handle(
+                        document(
+                            "auth-check-availability-conflict-nickname-success",
+                            requestFields(
+                                fieldWithPath("validationType").description("검사 유형 (NICKNAME)"),
+                                fieldWithPath("value").description("검사 대상 값")
+                            ),
+                            responseFields(
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("success").description("성공 여부")
+                            )
+                        )
+                    )
+                }
+            }
+        }
+
+        When("nickname이 이미 존재한다면") {
+            val request = ValidationRequest(ValidationRequest.ValidationType.NICKNAME, "existing_nickname")
+            every { authService.checkAvailability(request) } throws DuplicateNicknameException()
+            Then("에러 메시지, 409 Conflict, 요청 성공여부(false)를 응답한다.") {
+                mockMvc.post(url) {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(request)
+                }
+                .andExpect {
+                    status { isConflict() }
+                    jsonPath("$.data.message") { value("이미 사용 중인 닉네임 입니다.") }
+                    jsonPath("$.code") { value(409) }
+                    jsonPath("$.success") { value(false) }
+                }
+                .andDo {
+                    handle(
+                        document(
+                            "auth-check-availability-conflict-nickname-fail",
+                            requestFields(
+                                fieldWithPath("validationType").description("검사 유형 (NICKNAME)"),
+                                fieldWithPath("value").description("검사 대상 값")
+                            ),
+                            responseFields(
+                                fieldWithPath("data.message").description("에러 메시지"),
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("success").description("성공 여부")
+                            )
+                        )
+                    )
+                }
+            }
+        }
+    }
+})
+

--- a/src/test/kotlin/com/zunza/buythedip_kotlin/user/controller/AuthControllerSignupTest.kt
+++ b/src/test/kotlin/com/zunza/buythedip_kotlin/user/controller/AuthControllerSignupTest.kt
@@ -1,0 +1,72 @@
+package com.zunza.buythedip_kotlin.user.controller
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.ninjasquad.springmockk.MockkBean
+import com.zunza.buythedip_kotlin.config.SecurityConfig
+import com.zunza.buythedip_kotlin.user.dto.SignupRequest
+import com.zunza.buythedip_kotlin.user.service.AuthService
+import com.zunza.buythedip_kotlin.util.restDocMockMvcBuild
+import io.kotest.core.spec.style.BehaviorSpec
+import io.mockk.every
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest
+import org.springframework.context.annotation.Import
+import org.springframework.http.MediaType
+import org.springframework.restdocs.ManualRestDocumentation
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation.document
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.payload.PayloadDocumentation.requestFields
+import org.springframework.restdocs.payload.PayloadDocumentation.responseFields
+import org.springframework.test.web.servlet.post
+import org.springframework.web.context.WebApplicationContext
+
+@Import(SecurityConfig::class)
+@WebMvcTest(AuthController::class)
+class AuthControllerSignupTest(
+    @MockkBean private val authService: AuthService,
+    @Autowired private val objectMapper: ObjectMapper,
+    @Autowired private val context: WebApplicationContext
+) : BehaviorSpec({
+
+    val restDocumentation = ManualRestDocumentation()
+    val mockMvc = restDocMockMvcBuild(context, restDocumentation)
+
+    beforeEach { restDocumentation.beforeTest(javaClass, it.name.testName) }
+    afterEach { restDocumentation.afterTest() }
+
+    Given("회원가입 요청 시") {
+        val url = "/api/auth/signup"
+        When("유효한 요청 이라면") {
+            val signupRequest = SignupRequest("testId", "testpassword1!", "tester")
+            every { authService.signup(signupRequest) } returns Unit
+
+            Then("201 CREATED, 요청 성공여부(true)를 응답한다.") {
+                mockMvc.post(url) {
+                    contentType = MediaType.APPLICATION_JSON
+                    content = objectMapper.writeValueAsString(signupRequest)
+                }
+                .andExpect {
+                    status { isCreated() }
+                    jsonPath("$.code") { value(201) }
+                    jsonPath("$.success") { value(true) }
+                }
+                .andDo {
+                    handle(
+                        document(
+                            "signup-success",
+                            requestFields(
+                                fieldWithPath("accountId").description("계정 ID"),
+                                fieldWithPath("password").description("비밀번호"),
+                                fieldWithPath("nickname").description("닉네임")
+                            ),
+                            responseFields(
+                                fieldWithPath("code").description("응답 코드"),
+                                fieldWithPath("success").description("성공 여부")
+                            )
+                        )
+                    )
+                }
+            }
+        }
+    }
+})

--- a/src/test/kotlin/com/zunza/buythedip_kotlin/util/RestDocUtil.kt
+++ b/src/test/kotlin/com/zunza/buythedip_kotlin/util/RestDocUtil.kt
@@ -1,0 +1,25 @@
+package com.zunza.buythedip_kotlin.util
+
+import org.springframework.restdocs.RestDocumentationContextProvider
+import org.springframework.restdocs.mockmvc.MockMvcRestDocumentation
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.setup.DefaultMockMvcBuilder
+import org.springframework.test.web.servlet.setup.MockMvcBuilders
+import org.springframework.web.context.WebApplicationContext
+
+fun restDocMockMvcBuild(
+    context: WebApplicationContext,
+    restDocumentation: RestDocumentationContextProvider
+): MockMvc {
+    return MockMvcBuilders
+        .webAppContextSetup(context)
+        .apply<DefaultMockMvcBuilder>(
+            MockMvcRestDocumentation
+                .documentationConfiguration(restDocumentation)
+                .operationPreprocessors()
+                .withRequestDefaults(prettyPrint())
+                .withResponseDefaults(prettyPrint())
+        )
+        .build()
+}


### PR DESCRIPTION
1. 아이디/닉네임 중복 체크 API (POST /api/auth/validation/check-availability)
- ValidationRequest DTO 내의 validationType (Enum) 값을 통해, 하나의 API로 아이디와 닉네임 중복 검사를 모두 처리
- AuthService.checkAvailability: Kotlin의 when 표현식을 사용하여 validationType에 따라 적절한 검증 메서드를 동적으로 호출하도록 구현

2. 회원가입 API (POST /api/auth/signup)
- @Valid 어노테이션을 사용하여 SignupRequest DTO의 유효성 검증
- Spring Security의 PasswordEncoder를 사용하여 사용자의 비밀번호를 안전하게 해싱한 후 데이터베이스에 저장
- User.createUser()와 같은 정적 팩토리 메서드 패턴을 사용하여 User 엔티티 생성
