### PR TITLE
feat: JWT 발급, 검증, 필터링을 포함한 사용자 인증 기능 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtAuthenticationFilter.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtAuthenticationFilter.kt
@@ -1,0 +1,28 @@
+package com.zunza.buythedip_kotlin.security.jwt
+
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+
+class JwtAuthenticationFilter(
+    private val jwtTokenProvider: JwtTokenProvider
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        val token = extractJwtToken(request.getHeader(AUTHORIZATION_HEADER))
+
+        if (!token.isNullOrBlank() && jwtTokenProvider.validateToken(token)) {
+            val authentication = jwtTokenProvider.getAuthentication(token)
+            SecurityContextHolder.getContext().authentication = authentication
+        }
+
+        filterChain.doFilter(request, response)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtExceptionFilter.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtExceptionFilter.kt
@@ -1,0 +1,35 @@
+package com.zunza.buythedip_kotlin.security.jwt
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zunza.buythedip_kotlin.common.ApiResponse
+import com.zunza.buythedip_kotlin.common.ErrorResponse
+import io.jsonwebtoken.JwtException
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.MediaType
+import org.springframework.web.filter.OncePerRequestFilter
+
+class JwtExceptionFilter(
+    private val objectMapper: ObjectMapper
+) : OncePerRequestFilter() {
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        try {
+            filterChain.doFilter(request, response)
+        } catch (e: JwtException) {
+            val errorResponse = ErrorResponse(e.message)
+            val apiResponse = ApiResponse(errorResponse, HttpServletResponse.SC_UNAUTHORIZED)
+
+            response.status = HttpServletResponse.SC_UNAUTHORIZED
+            response.contentType = MediaType.APPLICATION_JSON.toString()
+            response.characterEncoding = "UTF-8"
+
+            objectMapper.writeValue(response.writer, apiResponse)
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtTokenProvider.kt
@@ -1,0 +1,80 @@
+package com.zunza.buythedip_kotlin.security.jwt
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import io.jsonwebtoken.JwtException
+import io.jsonwebtoken.Jwts
+import io.jsonwebtoken.security.Keys
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.stereotype.Component
+import java.time.Instant
+import java.util.Date
+import javax.crypto.SecretKey
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class JwtTokenProvider(
+    @Value("\${jwt.key}")
+    private val key: String,
+
+    @Value("\${jwt.access-token-expire-time}")
+    private val accessTokenExpireTime: Long,
+
+    @Value("\${jwt.refresh-token-expire-time}")
+    private val refreshTokenExpireTime: Long
+) {
+    fun generateAccessToken(userId: Long, roles: Collection<GrantedAuthority?>?): String {
+        val authorities = roles?.map { it?.authority }
+        val key = getKey()
+        val now = Instant.now()
+
+        return Jwts.builder()
+            .subject(userId.toString())
+            .claim("auth", authorities)
+            .issuedAt(Date(now.toEpochMilli()))
+            .expiration(Date(now.plusMillis(accessTokenExpireTime).toEpochMilli()))
+            .signWith(key, Jwts.SIG.HS256)
+            .compact()
+    }
+
+    fun generateRefreshToken(userId: Long): String {
+        val key = getKey()
+        val now = Instant.now()
+
+        return Jwts.builder()
+            .subject(userId.toString())
+            .issuedAt(Date(now.toEpochMilli()))
+            .expiration(Date(now.plusMillis(refreshTokenExpireTime).toEpochMilli()))
+            .signWith(key, Jwts.SIG.HS256)
+            .compact()
+    }
+
+    fun validateToken(token: String?): Boolean {
+        try {
+            Jwts.parser().verifyWith(getKey()).build().parseSignedClaims(token)
+            return true
+        } catch (e: JwtException) {
+            logger.warn { "${e.message}" }
+            throw e
+        }
+    }
+
+    fun getAuthentication(token: String?): Authentication {
+        val payload = Jwts.parser().verifyWith(getKey()).build().parseSignedClaims(token).payload
+        val userId = payload.subject as String
+        val authorities = payload["auth"] as? List<*>
+
+        return UsernamePasswordAuthenticationToken(userId.toLong(),
+            null,
+            authorities?.filterIsInstance<String>()
+                ?.map { SimpleGrantedAuthority(it) })
+    }
+
+    private fun getKey(): SecretKey {
+        return Keys.hmacShaKeyFor(this.key.toByteArray())
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/TokenUtils.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/TokenUtils.kt
@@ -1,0 +1,11 @@
+package com.zunza.buythedip_kotlin.security.jwt
+
+
+const val AUTHORIZATION_HEADER: String = "Authorization"
+const val TOKEN_PREFIX: String = "Bearer "
+
+fun extractJwtToken(authorizationHeader: String?): String? {
+    return authorizationHeader
+        ?.takeIf { it.startsWith(TOKEN_PREFIX) }
+        ?.substring(TOKEN_PREFIX.length )
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/user/CustomUserDetails.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/user/CustomUserDetails.kt
@@ -1,0 +1,46 @@
+package com.zunza.buythedip_kotlin.security.user
+
+import com.zunza.buythedip_kotlin.user.entity.User
+import org.springframework.security.core.GrantedAuthority
+import org.springframework.security.core.userdetails.UserDetails
+
+class CustomUserDetails(
+    private val user: User
+) : UserDetails {
+
+    override fun getAuthorities(): Collection<GrantedAuthority?>? {
+        return mutableListOf(GrantedAuthority { "ROLE_USER" })
+    }
+
+    override fun getPassword(): String {
+        return user.password
+    }
+
+    override fun getUsername(): String {
+        return user.accountId
+    }
+
+    fun getUserId(): Long {
+        return user.id
+    }
+
+    fun getNickname(): String {
+        return user.nickname
+    }
+
+    override fun isAccountNonExpired(): Boolean {
+        return true
+    }
+
+    override fun isAccountNonLocked(): Boolean {
+        return true
+    }
+
+    override fun isCredentialsNonExpired(): Boolean {
+        return true
+    }
+
+    override fun isEnabled(): Boolean {
+        return true
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/user/CustomUserDetailsService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/user/CustomUserDetailsService.kt
@@ -1,0 +1,20 @@
+package com.zunza.buythedip_kotlin.security.user
+
+import com.zunza.buythedip_kotlin.user.exception.UserNotFoundException
+import com.zunza.buythedip_kotlin.user.repository.UserRepository
+import org.springframework.security.core.userdetails.UserDetails
+import org.springframework.security.core.userdetails.UserDetailsService
+import org.springframework.stereotype.Service
+
+@Service
+class CustomUserDetailsService(
+    private val userRepository: UserRepository
+) : UserDetailsService {
+
+    override fun loadUserByUsername(username: String?): UserDetails? {
+        val user = userRepository.findByAccountId(username)
+            ?: throw UserNotFoundException(username)
+
+        return CustomUserDetails(user)
+    }
+}


### PR DESCRIPTION
1. 로그인 성공 
- AuthService는 AuthenticationManager를 통해 인증에 성공하면, JwtTokenProvider를 호출하여 Access Token과 Refresh Token을 생성하고 클라이언트에게 전달

2. API 요청
- 클라이언트는 이후 모든 요청의 Authorization 헤더에 Bearer {AccessToken} 형태로 토큰을 담아 보냄

3. JwtExceptionFilte: 
- 필터 체인의 가장 앞에서 JWT 파싱 과정에서 발생할 수 있는 모든 JwtException(만료, 서명 오류 등)을 try-catch로 감지하여 401 Unauthorized 오류 응답을 생성

4. JwtAuthenticationFilter
- 요청 헤더에서 Access Token을 추출하고 토큰의 유효성을 검증
- 토큰이 유효하면 토큰의 payload로부터 userId와 authorities를 추출하고, 이를 기반으로 Authentication 객체를 생성하고SecurityContextHolder에 설정. 

5. CustomUserDetailsService
- 초기 로그인 과정에서 AuthenticationManager에 의해 호출
- accountId를 기반으로 DB에서 User 정보를 조회하고, 이를 CustomUserDetails로 래핑하여 Spring Security가 이해할 수 있는 형태로 변환해주는 어댑터 역할을 수행