### PR TITLE
feat: 로그인, 로그아웃 기능 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/SecurityConfig.kt
@@ -1,21 +1,37 @@
 package com.zunza.buythedip_kotlin.config
 
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zunza.buythedip_kotlin.security.jwt.JwtAuthenticationFilter
+import com.zunza.buythedip_kotlin.security.jwt.JwtExceptionFilter
+import com.zunza.buythedip_kotlin.security.jwt.JwtTokenProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration
 import org.springframework.security.config.annotation.web.builders.HttpSecurity
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
 
 @Configuration
 @EnableWebSecurity
-class SecurityConfig {
+class SecurityConfig(
+    private val authenticationConfiguration: AuthenticationConfiguration,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val objectMapper: ObjectMapper
+) {
 
     @Bean
     fun passwordEncoder(): PasswordEncoder {
         return BCryptPasswordEncoder()
+    }
+
+    @Bean
+    fun authenticationManager(): AuthenticationManager {
+        return authenticationConfiguration.authenticationManager
     }
 
     @Bean
@@ -33,6 +49,14 @@ class SecurityConfig {
                 authorize
                     .anyRequest().permitAll()
             }
+
+            .addFilterBefore(JwtExceptionFilter(objectMapper),
+                UsernamePasswordAuthenticationFilter::class.java
+                )
+
+            .addFilterBefore(JwtAuthenticationFilter(jwtTokenProvider),
+                UsernamePasswordAuthenticationFilter::class.java
+                )
 
         return http.build()
     }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/RedisKey.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/RedisKey.kt
@@ -1,0 +1,7 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis
+
+enum class RedisKey(
+    val value: String
+) {
+    REFRESH_TOKEN_KEY_PREFIX("RT:");
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/RefreshTokenRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/RefreshTokenRepository.kt
@@ -1,0 +1,24 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis
+
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Component
+import java.util.concurrent.TimeUnit
+
+@Component
+class RefreshTokenRepository(
+    private val redisTemplate: RedisTemplate<String, Any>,
+
+    @Value("\${jwt.refresh-token-expire-time}")
+    private val ttl: Long
+) {
+    fun save(userId: Long, refreshToken: String) = redisTemplate.opsForValue()
+        .set(getKey(userId), refreshToken, ttl, TimeUnit.MILLISECONDS)
+
+    fun get(userId: Long): String? = redisTemplate.opsForValue().get(getKey(userId)).toString()
+
+    fun delete(userId: Long) = redisTemplate.delete(getKey(userId))
+
+    private fun getKey(userId: Long): String = RedisKey.REFRESH_TOKEN_KEY_PREFIX.value + userId
+}
+

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/controller/AuthController.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/controller/AuthController.kt
@@ -1,14 +1,20 @@
 package com.zunza.buythedip_kotlin.user.controller
 
+import com.zunza.buythedip_kotlin.user.dto.LoginRequest
+import com.zunza.buythedip_kotlin.user.dto.LoginResponse
 import com.zunza.buythedip_kotlin.user.dto.SignupRequest
 import com.zunza.buythedip_kotlin.user.dto.ValidationRequest
 import com.zunza.buythedip_kotlin.user.service.AuthService
 import jakarta.servlet.http.HttpServletResponse.*
 import jakarta.validation.Valid
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
 import org.springframework.http.ResponseEntity
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
+import java.time.Duration
 
 @RestController
 class AuthController(
@@ -29,4 +35,39 @@ class AuthController(
         authService.signup(signupRequest)
         return ResponseEntity.status(SC_CREATED).build()
     }
+
+    @PostMapping("/api/auth/login")
+    fun login(
+        @RequestBody loginRequest: LoginRequest
+    ): ResponseEntity<LoginResponse> {
+        val loginSuccessDto = authService.login(loginRequest)
+        val responseCookie = getHttpOnlyCookie(loginSuccessDto.refreshToken, 7L)
+
+        return ResponseEntity.ok()
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+            .body(LoginResponse(loginSuccessDto.nickname, loginSuccessDto.accessToken))
+    }
+
+    @PostMapping("/api/auth/logout")
+    fun logout(
+        @AuthenticationPrincipal userId: Long
+    ): ResponseEntity<Unit> {
+        authService.logout(userId)
+        val responseCookie = getHttpOnlyCookie("", 0)
+
+        return ResponseEntity
+            .status(SC_OK)
+            .header(HttpHeaders.SET_COOKIE, responseCookie.toString())
+            .build()
+    }
+
+    fun getHttpOnlyCookie(
+        value: String,
+        maxAge: Long
+    ): ResponseCookie = ResponseCookie.from("refreshToken", value)
+            .httpOnly(true)
+            .path("/")
+            .maxAge(Duration.ofDays(maxAge))
+            .build()
+
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/dto/LoginDto.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/dto/LoginDto.kt
@@ -1,0 +1,12 @@
+package com.zunza.buythedip_kotlin.user.dto
+
+
+data class LoginRequest(
+    val accountId: String,
+    val password: String
+)
+
+data class LoginResponse(
+    val nickname: String,
+    val accessToken: String
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/dto/LoginSuccessDto.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/dto/LoginSuccessDto.kt
@@ -1,0 +1,7 @@
+package com.zunza.buythedip_kotlin.user.dto
+
+data class LoginSuccessDto(
+    val accessToken: String,
+    val refreshToken: String,
+    val nickname: String
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/exception/UserNotFoundException.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/exception/UserNotFoundException.kt
@@ -1,0 +1,11 @@
+package com.zunza.buythedip_kotlin.user.exception
+
+import com.zunza.buythedip_kotlin.common.CustomException
+import jakarta.servlet.http.HttpServletResponse
+
+class UserNotFoundException : CustomException {
+    constructor(accountId: String?) : super("존재하지 않는 사용자입니다. ACCOUNT ID: $accountId")
+    constructor(userId: Long) : super("존재하지 않는 사용자입니다. USER ID: $userId")
+
+    override fun getStatusCode(): Int = HttpServletResponse.SC_NOT_FOUND
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/repository/UserRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/repository/UserRepository.kt
@@ -8,4 +8,5 @@ import org.springframework.stereotype.Repository
 interface UserRepository : JpaRepository<User, Long> {
     fun existsByAccountId(accountId: String): Boolean
     fun existsByNickname(nickname: String): Boolean
+    fun findByAccountId(accountId: String?): User?
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/user/service/AuthService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/user/service/AuthService.kt
@@ -1,5 +1,10 @@
 package com.zunza.buythedip_kotlin.user.service
 
+import com.zunza.buythedip_kotlin.infrastructure.redis.RefreshTokenRepository
+import com.zunza.buythedip_kotlin.security.jwt.JwtTokenProvider
+import com.zunza.buythedip_kotlin.security.user.CustomUserDetails
+import com.zunza.buythedip_kotlin.user.dto.LoginRequest
+import com.zunza.buythedip_kotlin.user.dto.LoginSuccessDto
 import com.zunza.buythedip_kotlin.user.dto.SignupRequest
 import com.zunza.buythedip_kotlin.user.dto.ValidationRequest
 import com.zunza.buythedip_kotlin.user.dto.ValidationRequest.ValidationType.*
@@ -7,13 +12,18 @@ import com.zunza.buythedip_kotlin.user.entity.User
 import com.zunza.buythedip_kotlin.user.exception.DuplicateAccountIdException
 import com.zunza.buythedip_kotlin.user.exception.DuplicateNicknameException
 import com.zunza.buythedip_kotlin.user.repository.UserRepository
+import org.springframework.security.authentication.AuthenticationManager
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 
 @Service
 class AuthService(
     private val userRepository: UserRepository,
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
+    private val authenticationManager: AuthenticationManager,
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val refreshTokenRepository: RefreshTokenRepository
 ) {
     fun checkAvailability(validationRequest: ValidationRequest) {
         when (validationRequest.validationType) {
@@ -26,6 +36,22 @@ class AuthService(
         val encodedPassword: String = passwordEncoder.encode(signupRequest.password)
         val user = User.createUser(signupRequest.accountId, encodedPassword, signupRequest.nickname)
         userRepository.save(user)
+    }
+
+    fun login(loginRequest: LoginRequest): LoginSuccessDto {
+        val authenticationToken = UsernamePasswordAuthenticationToken(loginRequest.accountId, loginRequest.password)
+        val authenticate = authenticationManager.authenticate(authenticationToken)
+        val principal = authenticate.principal as CustomUserDetails
+
+        val accessToken = jwtTokenProvider.generateAccessToken(principal.getUserId(), principal.authorities)
+        val refreshToken = jwtTokenProvider.generateRefreshToken(principal.getUserId())
+        refreshTokenRepository.save(principal.getUserId(), refreshToken)
+
+        return LoginSuccessDto(accessToken, refreshToken, principal.getNickname())
+    }
+
+    fun logout(userId: Long) {
+        refreshTokenRepository.delete(userId)
     }
 
     private fun checkAccountIdAvailability(value: String) {


### PR DESCRIPTION
1. 로그인 (POST /api/auth/login)
- AuthenticationManager를 통해 사용자의 아이디와 비밀번호를 검증
- 인증 성공 시, JwtTokenProvider를 통해 Access Token과 Refresh Token을 각각 생성
- 발급된 Refresh Token은 사용자의 userId를 키로 하여 Redis에 저장
- Access Token은 API 요청에 사용될 수 있도록 응답 본문에 담아 클라이언트에게 전달
- Refresh Token: XSS 공격으로부터 보호하기 위해, JavaScript에서 접근할 수 없는 HttpOnly 쿠키에 담아 응답 헤더로 전달

2. 로그아웃 (POST /api/auth/logout)
- @AuthenticationPrincipal을 통해 현재 로그인된 사용자의 userId를 식별
- RefreshTokenRepository를 통해 Redis에 저장된 해당 사용자의 Refresh Token 삭제
- 클라이언트 측의 토큰을 무효화하기 위해, 내용이 비어있고 만료 시간이 0인 만료 쿠키를 응답 헤더에 설정하여 전달