### PR TITLE
feat: 커서 기반 페이지네이션과 캐싱을 적용한 뉴스 목록/상세 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/QueryDSLConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/QueryDSLConfig.kt
@@ -1,0 +1,17 @@
+package com.zunza.buythedip_kotlin.config
+
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+
+@Configuration
+class QueryDSLConfig(
+    private val entityManager: EntityManager
+) {
+
+    @Bean
+    fun jpaQueryFactory(): JPAQueryFactory {
+        return JPAQueryFactory(entityManager)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisCacheConfig.kt
@@ -1,0 +1,36 @@
+package com.zunza.buythedip_kotlin.config
+
+import com.zunza.buythedip_kotlin.infrastructure.redis.CacheType
+import org.springframework.cache.CacheManager
+import org.springframework.cache.annotation.EnableCaching
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.cache.RedisCacheConfiguration
+import org.springframework.data.redis.cache.RedisCacheManager
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer
+import org.springframework.data.redis.serializer.RedisSerializationContext
+import org.springframework.data.redis.serializer.StringRedisSerializer
+import java.time.Duration
+
+@EnableCaching
+@Configuration
+class RedisCacheConfig {
+
+    @Bean
+    fun cacheManager(redisConnectionFactory: RedisConnectionFactory): CacheManager {
+        val defaultConfig = RedisCacheConfiguration.defaultCacheConfig()
+            .serializeKeysWith(RedisSerializationContext.SerializationPair.fromSerializer(StringRedisSerializer()))
+            .serializeValuesWith(RedisSerializationContext.SerializationPair.fromSerializer(GenericJackson2JsonRedisSerializer()))
+
+        val cacheConfiguration: Map<String, RedisCacheConfiguration> = CacheType.entries
+            .associate { cacheType ->
+                cacheType.cacheName to defaultConfig.entryTtl(cacheType.ttl)
+            }
+
+        return RedisCacheManager.builder(redisConnectionFactory)
+            .cacheDefaults(defaultConfig.entryTtl(Duration.ofMinutes(1)))
+            .withInitialCacheConfigurations(cacheConfiguration)
+            .build()
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/CacheType.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/CacheType.kt
@@ -1,0 +1,11 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis
+
+import java.time.Duration
+
+enum class CacheType(
+    val cacheName: String,
+    val ttl: Duration
+) {
+    NEWS_PAGE("NEWS:PAGE", Duration.ofMinutes(30)),
+//    NEWS_DETAIL("NEWS:DETAIL:", Duration.ofMinutes(10))
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/news/controller/NewsController.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/news/controller/NewsController.kt
@@ -1,0 +1,30 @@
+package com.zunza.buythedip_kotlin.news.controller
+
+import com.zunza.buythedip_kotlin.news.dto.NewsCursorRequest
+import com.zunza.buythedip_kotlin.news.dto.NewsDetailResponse
+import com.zunza.buythedip_kotlin.news.dto.NewsPageResponse
+import com.zunza.buythedip_kotlin.news.service.NewsService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class NewsController(
+    private val newsService: NewsService
+) {
+    @GetMapping("/api/news")
+    fun getNewsPage(
+        @ModelAttribute newsCursor: NewsCursorRequest
+    ): ResponseEntity<NewsPageResponse> {
+        return ResponseEntity.ok(newsService.getNewsPage(newsCursor))
+    }
+
+    @GetMapping("/api/news/{newsId}")
+    fun getNewsDetail(
+        @PathVariable newsId: Long
+    ): ResponseEntity<NewsDetailResponse> {
+        return ResponseEntity.ok(newsService.getNewsDetail(newsId))
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/news/dto/NewsDetailResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/news/dto/NewsDetailResponse.kt
@@ -1,0 +1,25 @@
+package com.zunza.buythedip_kotlin.news.dto
+
+import com.zunza.buythedip_kotlin.news.entity.News
+
+data class NewsDetailResponse(
+    val newsId: Long = 0,
+    val headline: String = "",
+    val summary: String = "",
+    val source: String = "",
+    val url: String = "",
+    val datetime: Long = 0
+) {
+    companion object {
+        fun createFrom(news: News): NewsDetailResponse {
+             return NewsDetailResponse(
+                news.id,
+                news.headline,
+                news.summary,
+                news.source,
+                news.url,
+                news.datetime
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/news/dto/NewsPageDto.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/news/dto/NewsPageDto.kt
@@ -1,0 +1,24 @@
+package com.zunza.buythedip_kotlin.news.dto
+
+
+data class NewsCursorRequest(
+    val newsId: Long = 0,
+    val datetime: Long = 0
+)
+
+data class NewsPreview(
+    val newsId: Long = 0,
+    val headline: String = "",
+    val datetime: Long = 0
+)
+
+data class NextCursor(
+    val newsId: Long? = null,
+    val datetime: Long? = null
+)
+
+data class NewsPageResponse(
+    val newsPreviews: List<NewsPreview> = emptyList(),
+    val nextCursor: NextCursor? = null,
+    val hasMore: Boolean = false
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/news/exception/NewsNotFoundException.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/news/exception/NewsNotFoundException.kt
@@ -1,0 +1,15 @@
+package com.zunza.buythedip_kotlin.news.exception
+
+import com.zunza.buythedip_kotlin.common.CustomException
+import jakarta.servlet.http.HttpServletResponse.*
+
+class NewsNotFoundException(
+    val newsId: Long
+) : CustomException(MESSAGE + newsId) {
+
+    companion object {
+        private const val MESSAGE = "존재하지 않는 뉴스 입니다. NEWS ID: "
+    }
+
+    override fun getStatusCode(): Int  = SC_NOT_FOUND
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/news/repository/CustomNewsRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/news/repository/CustomNewsRepository.kt
@@ -1,0 +1,8 @@
+package com.zunza.buythedip_kotlin.news.repository
+
+import com.zunza.buythedip_kotlin.news.dto.NewsCursorRequest
+import com.zunza.buythedip_kotlin.news.dto.NewsPageResponse
+
+interface CustomNewsRepository {
+    fun findNewsPageByCursor(newsCursor: NewsCursorRequest): NewsPageResponse
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/news/repository/CustomNewsRepositoryImpl.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/news/repository/CustomNewsRepositoryImpl.kt
@@ -1,0 +1,67 @@
+package com.zunza.buythedip_kotlin.news.repository
+
+import com.querydsl.core.types.Projections
+import com.querydsl.core.types.dsl.BooleanExpression
+import com.querydsl.jpa.impl.JPAQueryFactory
+import com.zunza.buythedip_kotlin.news.dto.NewsCursorRequest
+import com.zunza.buythedip_kotlin.news.dto.NewsPageResponse
+import com.zunza.buythedip_kotlin.news.dto.NewsPreview
+import com.zunza.buythedip_kotlin.news.dto.NextCursor
+import com.zunza.buythedip_kotlin.news.entity.QNews
+import org.springframework.stereotype.Repository
+
+@Repository
+class CustomNewsRepositoryImpl(
+    private val jpaQueryFactory: JPAQueryFactory,
+    private val news: QNews = QNews.news
+) : CustomNewsRepository {
+
+    companion object{
+        private const val SIZE = 15L
+    }
+
+    override fun findNewsPageByCursor(newsCursor: NewsCursorRequest): NewsPageResponse {
+        val result: MutableList<NewsPreview> = jpaQueryFactory
+            .select(Projections.constructor(
+                    NewsPreview::class.java,
+                    news.id,
+                    news.headline,
+                    news.datetime
+                )
+            )
+            .from(news)
+            .where(cursorCondition(newsCursor))
+            .orderBy(news.datetime.desc(), news.id.desc())
+            .limit(SIZE + 1)
+            .fetch()
+            .toMutableList()
+
+        val nextCursor = getNextCursor(result)
+        val hasMore = result.hasMore()
+        if (result.count() > SIZE) result.removeLast()
+
+        return NewsPageResponse(
+            result,
+            nextCursor,
+            hasMore
+        )
+    }
+
+    private fun cursorCondition(newsCursor: NewsCursorRequest): BooleanExpression? {
+        return when (newsCursor.datetime) {
+            0L -> null
+            else -> news.datetime.lt(newsCursor.datetime)
+                .or(news.datetime.eq(newsCursor.datetime)
+                    .and(news.id.lt(newsCursor.newsId)))
+        }
+    }
+
+    private fun getNextCursor(result: MutableList<NewsPreview>): NextCursor {
+        return when {
+            result.count() > SIZE -> NextCursor(result.last().newsId, result.last().datetime)
+            else -> NextCursor()
+        }
+    }
+
+    private fun MutableList<NewsPreview>.hasMore(): Boolean = this.count() > SIZE
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/news/repository/NewsRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/news/repository/NewsRepository.kt
@@ -5,5 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface NewsRepository : JpaRepository<News, Long>{
+interface NewsRepository : JpaRepository<News, Long>, CustomNewsRepository {
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/news/service/NewsService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/news/service/NewsService.kt
@@ -1,0 +1,27 @@
+package com.zunza.buythedip_kotlin.news.service
+
+import com.zunza.buythedip_kotlin.news.dto.NewsCursorRequest
+import com.zunza.buythedip_kotlin.news.dto.NewsDetailResponse
+import com.zunza.buythedip_kotlin.news.dto.NewsPageResponse
+import com.zunza.buythedip_kotlin.news.exception.NewsNotFoundException
+import com.zunza.buythedip_kotlin.news.repository.NewsRepository
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.stereotype.Service
+
+@Service
+class NewsService(
+    private val newsRepository: NewsRepository
+) {
+    @Cacheable(cacheNames = ["NEWS:PAGE"], key = "#newsCursor.datetime")
+    fun getNewsPage(newsCursor: NewsCursorRequest): NewsPageResponse {
+        return newsRepository.findNewsPageByCursor(newsCursor)
+    }
+
+    @Cacheable(cacheNames = ["NEWS:DETAIL"], key = "#newsId")
+    fun getNewsDetail(newsId: Long): NewsDetailResponse {
+        return newsRepository.findByIdOrNull(newsId)
+            ?.let { news ->  NewsDetailResponse.createFrom(news) }
+            ?: throw NewsNotFoundException(newsId)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/news/service/NewsStorageService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/news/service/NewsStorageService.kt
@@ -6,6 +6,7 @@ import com.zunza.buythedip_kotlin.news.repository.NewsRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.withContext
+import org.springframework.cache.annotation.CacheEvict
 import org.springframework.stereotype.Service
 
 private val logger = KotlinLogging.logger {  }
@@ -14,6 +15,7 @@ private val logger = KotlinLogging.logger {  }
 class NewsStorageService(
     private val newsRepository: NewsRepository
 ) {
+    @CacheEvict(cacheNames = ["NEWS:PAGE"], allEntries = true)
     suspend fun saveNews(translatedNewsList: List<TranslatedNewsDto>) {
         withContext(Dispatchers.IO) {
             newsRepository.saveAll(translatedNewsList.map { translatedNews ->


### PR DESCRIPTION
1. 뉴스 목록 조회 (GET /api/news)
- 커서 기반 페이지네이션:
   - 페이지 사이즈보다 하나 더 많은 데이터를 조회하여 다음 페이지가 존재하는지에 대한 여부와 다음 페이지 요청을 위해 사용할 커서 정보를 포함

- Querydsl 동적 쿼리:
   - where(cursorCondition(...))를 통해, 첫 페이지 요청과 이후 페이지 요청에 대한 WHERE 절을 동적으로 생성
   - 커서 조건은 (datetime < ?) OR (datetime = ? AND id < ?) 형태의 복합 조건을 사용 또한 복합 인덱스를 활용하고 filesort를 방지

- 페이지 캐싱 (@Cacheable):
   - NewsService.getNewsPage 메서드에 @Cacheable를 적용
   - 페이지별로 캐싱하기 위해, 커서 정보(datetime)를 조합하여 캐시 키를 생성

2. 뉴스 상세 조회 (GET /api/news/{newsId})
- 개별 항목 캐싱 (@Cacheable):
   - NewsService.getNewsDetail 메서드에 @Cacheable 적용

3. 캐시 무효화 전략 (@CacheEvict)
- NewsStorageService.saveNews 메서드(뉴스 저장 로직)에 @CacheEvict을 추가
- 새로운 뉴스가 저장되면 기존의 페이지 순서가 변경되므로, 뉴스 목록 페이지에 대한 모든 캐시를 일괄적으로 무효화하여 데이터 정합성을 보장
- 뉴스 상세 캐시는 별도에 무효화를 하지 않는 대신 TTL을 짧게 설정(10분)