### PR TITLE
feat: Interceptor와 커스텀 예외 핸들러를 이용한 WebSocket 보안 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/SecurityConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/SecurityConfig.kt
@@ -47,6 +47,7 @@ class SecurityConfig(
 
             .authorizeHttpRequests { authorize ->
                 authorize
+                    .requestMatchers("/ws/chat/**").permitAll()
                     .anyRequest().permitAll()
             }
 

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebConfig.kt
@@ -1,0 +1,16 @@
+package com.zunza.buythedip_kotlin.config
+
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.servlet.config.annotation.CorsRegistry
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer
+
+@Configuration
+class WebConfig : WebMvcConfigurer {
+
+    override fun addCorsMappings(registry: CorsRegistry) {
+        registry.addMapping("/**")
+            .allowedOrigins("http://localhost:5173")
+            .allowedMethods("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            .allowCredentials(true);
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebSocketConfig.kt
@@ -1,0 +1,36 @@
+package com.zunza.buythedip_kotlin.config
+
+import com.zunza.buythedip_kotlin.security.jwt.JwtChannelInterceptor
+import com.zunza.buythedip_kotlin.security.websocket.StompExceptionHandler
+import com.zunza.buythedip_kotlin.security.websocket.WebSocketHandShakeInterceptor
+import org.springframework.context.annotation.Configuration
+import org.springframework.messaging.simp.config.ChannelRegistration
+import org.springframework.messaging.simp.config.MessageBrokerRegistry
+import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker
+import org.springframework.web.socket.config.annotation.StompEndpointRegistry
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer
+
+
+@Configuration
+@EnableWebSocketMessageBroker
+class WebSocketConfig(
+    private val jwtChannelInterceptor: JwtChannelInterceptor
+) : WebSocketMessageBrokerConfigurer {
+
+    override fun registerStompEndpoints(registry: StompEndpointRegistry) {
+        registry.setErrorHandler(StompExceptionHandler())
+        registry.addEndpoint("/ws/chat")
+            .addInterceptors(WebSocketHandShakeInterceptor())
+            .setAllowedOriginPatterns("*")
+            .withSockJS()
+    }
+
+    override fun configureMessageBroker(registry: MessageBrokerRegistry) {
+        registry.enableSimpleBroker("/topic", "/queue")
+        registry.setApplicationDestinationPrefixes("/app")
+    }
+
+    override fun configureClientInboundChannel(registration: ChannelRegistration) {
+        registration.interceptors(jwtChannelInterceptor)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtChannelInterceptor.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtChannelInterceptor.kt
@@ -1,0 +1,89 @@
+package com.zunza.buythedip_kotlin.security.jwt
+
+import com.zunza.buythedip_kotlin.security.websocket.exception.InvalidAuthorizationHeaderException
+import com.zunza.buythedip_kotlin.security.user.CustomUserDetails
+import com.zunza.buythedip_kotlin.security.websocket.exception.StompAuthenticationFailedException
+import com.zunza.buythedip_kotlin.user.exception.UserNotFoundException
+import com.zunza.buythedip_kotlin.user.repository.UserRepository
+import io.jsonwebtoken.Claims
+import org.springframework.data.repository.findByIdOrNull
+import org.springframework.messaging.Message
+import org.springframework.messaging.MessageChannel
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.ChannelInterceptor
+import org.springframework.messaging.support.MessageHeaderAccessor
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.Authentication
+import org.springframework.stereotype.Component
+import kotlin.text.startsWith
+
+
+@Component
+class JwtChannelInterceptor(
+    private val jwtTokenProvider: JwtTokenProvider,
+    private val userRepository: UserRepository
+) : ChannelInterceptor {
+
+    override fun preSend(
+        message: Message<*>,
+        channel: MessageChannel
+    ): Message<*>? {
+        val accessor = MessageHeaderAccessor.getAccessor(message, StompHeaderAccessor::class.java)
+            ?: return message
+
+        return when (accessor.command) {
+            StompCommand.CONNECT -> handleConnect(accessor, message)
+            StompCommand.SEND, StompCommand.SUBSCRIBE -> handleAuthenticated(accessor, message)
+            StompCommand.DISCONNECT -> message
+            else -> message
+        }
+    }
+
+    private fun handleConnect(
+        accessor: StompHeaderAccessor,
+        message: Message<*>
+    ): Message<*> {
+        val endpoint = accessor.sessionAttributes?.get("endpoint") as String
+        if (!endpoint.startsWith("/ws/chat")) return message
+
+        val authorization = accessor.getFirstNativeHeader(AUTHORIZATION_HEADER)
+        if (authorization.isNullOrBlank() || !authorization.startsWith(TOKEN_PREFIX)) {
+            throw InvalidAuthorizationHeaderException()
+        }
+
+        val token = authorization.removePrefix(TOKEN_PREFIX)
+        jwtTokenProvider.validateToken(token)
+
+        val claims = jwtTokenProvider.getClaims(token)
+        accessor.user = getAuthentication(claims)
+
+        return message
+    }
+
+    private fun handleAuthenticated(
+        accessor: StompHeaderAccessor,
+        message: Message<*>
+    ): Message<*> {
+        val endpoint = accessor.sessionAttributes?.get("endpoint") as String
+        if (!endpoint.startsWith("/ws/chat")) return message
+
+        return when {
+            accessor.user == null -> throw StompAuthenticationFailedException(accessor.command.toString())
+            else -> message
+        }
+    }
+
+    private fun getAuthentication(claims: Claims): Authentication {
+        val userId = claims.subject as String
+        val user = userRepository.findByIdOrNull(userId.toLong())
+            ?: throw UserNotFoundException(userId.toLong())
+
+        val details = CustomUserDetails(user)
+        return UsernamePasswordAuthenticationToken(
+            details,
+            null,
+            details.authorities
+        )
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtTokenProvider.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/jwt/JwtTokenProvider.kt
@@ -1,6 +1,7 @@
 package com.zunza.buythedip_kotlin.security.jwt
 
 import io.github.oshai.kotlinlogging.KotlinLogging
+import io.jsonwebtoken.Claims
 import io.jsonwebtoken.JwtException
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
@@ -63,16 +64,21 @@ class JwtTokenProvider(
         }
     }
 
-    fun getAuthentication(token: String?): Authentication {
-        val payload = Jwts.parser().verifyWith(getKey()).build().parseSignedClaims(token).payload
-        val userId = payload.subject as String
-        val authorities = payload["auth"] as? List<*>
+    fun getAuthentication(token: String): Authentication {
+        val claims = getClaims(token)
+        val userId = claims.subject as String
+        val authorities = claims["auth"] as? List<*>
 
         return UsernamePasswordAuthenticationToken(userId.toLong(),
             null,
             authorities?.filterIsInstance<String>()
                 ?.map { SimpleGrantedAuthority(it) })
     }
+
+    fun getClaims(token: String): Claims {
+        return Jwts.parser().verifyWith(getKey()).build().parseSignedClaims(token).payload
+    }
+
 
     private fun getKey(): SecretKey {
         return Keys.hmacShaKeyFor(this.key.toByteArray())

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/websocket/StompExceptionHandler.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/websocket/StompExceptionHandler.kt
@@ -1,0 +1,39 @@
+package com.zunza.buythedip_kotlin.security.websocket
+
+import com.zunza.buythedip_kotlin.security.websocket.exception.InvalidAuthorizationHeaderException
+import com.zunza.buythedip_kotlin.security.websocket.exception.StompAuthenticationFailedException
+import io.jsonwebtoken.JwtException
+import jakarta.servlet.http.HttpServletResponse.*
+import org.springframework.messaging.Message
+import org.springframework.messaging.simp.stomp.StompCommand
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.messaging.support.MessageBuilder
+import org.springframework.web.socket.messaging.StompSubProtocolErrorHandler
+
+class StompExceptionHandler : StompSubProtocolErrorHandler() {
+
+    override fun handleClientMessageProcessingError(
+        clientMessage: Message<ByteArray?>?,
+        ex: Throwable
+    ): Message<ByteArray?>? {
+        val actualException = ex.cause
+        when (actualException) {
+            is JwtException -> return createErrorMessage(actualException.message!!)
+            is InvalidAuthorizationHeaderException -> return createErrorMessage(actualException.message!!)
+            is StompAuthenticationFailedException -> return createErrorMessage(actualException.message!!)
+        }
+
+        return null
+    }
+
+    private fun createErrorMessage(message: String): Message<ByteArray?> {
+        val headers = StompHeaderAccessor.create(StompCommand.ERROR)
+        headers.message = message
+        headers.addNativeHeader("error-code", SC_UNAUTHORIZED.toString())
+
+        return MessageBuilder.createMessage(
+            message.toByteArray(),
+            headers.messageHeaders
+        )
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/websocket/WebSocketHandShakeInterceptor.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/websocket/WebSocketHandShakeInterceptor.kt
@@ -1,0 +1,35 @@
+package com.zunza.buythedip_kotlin.security.websocket
+
+import org.springframework.http.server.ServerHttpRequest
+import org.springframework.http.server.ServerHttpResponse
+import org.springframework.http.server.ServletServerHttpRequest
+import org.springframework.web.socket.WebSocketHandler
+import org.springframework.web.socket.server.HandshakeInterceptor
+import java.lang.Exception
+
+
+class WebSocketHandShakeInterceptor : HandshakeInterceptor {
+
+    override fun beforeHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        attributes: MutableMap<String?, Any?>
+    ): Boolean {
+
+        if (request is ServletServerHttpRequest) {
+            val path = request.servletRequest.requestURI
+            attributes["endpoint"] = path
+        }
+
+        return true
+    }
+
+    override fun afterHandshake(
+        request: ServerHttpRequest,
+        response: ServerHttpResponse,
+        wsHandler: WebSocketHandler,
+        exception: Exception?
+    ) {
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/websocket/exception/InvalidAuthorizationHeaderException.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/websocket/exception/InvalidAuthorizationHeaderException.kt
@@ -1,0 +1,13 @@
+package com.zunza.buythedip_kotlin.security.websocket.exception
+
+import com.zunza.buythedip_kotlin.common.CustomException
+import jakarta.servlet.http.HttpServletResponse.*
+
+class InvalidAuthorizationHeaderException : CustomException(MESSAGE) {
+
+    companion object {
+        private const val MESSAGE = "Invalid Authorization header"
+    }
+
+    override fun getStatusCode() = SC_UNAUTHORIZED
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/security/websocket/exception/StompAuthenticationFailedException.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/security/websocket/exception/StompAuthenticationFailedException.kt
@@ -1,0 +1,14 @@
+package com.zunza.buythedip_kotlin.security.websocket.exception
+
+import com.zunza.buythedip_kotlin.common.CustomException
+import jakarta.servlet.http.HttpServletResponse.*
+
+class StompAuthenticationFailedException (
+    val command: String
+) : CustomException(MESSAGE + command) {
+    companion object {
+        private const val MESSAGE = "Authentication principal not set in STOMP request [COMMAND]: "
+    }
+
+    override fun getStatusCode() = SC_UNAUTHORIZED
+}


### PR DESCRIPTION
1. 엔드포인트 경로 식별 (WebSocketHandShakeInterceptor)
 - HTTP 핸드셰이크 단계에서 beforeHandshake 메서드를 통해 WebSocket 연결 요청을 가로챔
 - 요청 URI을 WebSocket 세션 속성(attributes)에 endpoint라는 키로 저장

2. 동적 인증 처리 (JwtChannelInterceptor)
- ChannelInterceptor는 HandshakeInterceptor가 저장해 둔 endpoint 값을 확인
- CONNECT 시:
   - endpoint가 인증이 필요한 채팅 엔드포인트일 경우에만 Authorization 헤더의 JWT 토큰 검증을 수행
   - 인증 성공 시, Authentication 객체를 생성하여 STOMP 세션의 user로 설정
   - 만약 인증이 필요 없는 다른 엔드포인트라면, 아무런 검증 없이 연결을 통과

- SEND/SUBSCRIBE 시:
   - endpoint를 확인하여, 채팅 관련 요청일 경우 STOMP 세션에 user 정보가 존재하는지 검사. 인증되지 않은 사용자의 메시지 전송/구독 시도를 차단

3. 커스텀 STOMP 예외 처리 (StompExceptionHandler)
- StompSubProtocolErrorHandler를 상속받아, WebSocket 통신 중 발생하는 예외를 처리하는 핸들러 구현
- handleClientMessageProcessingError 메서드에서, JwtChannelInterceptor 등에서 발생한 예외를 감지
- 클라이언트에게 ERROR STOMP 프레임을 생성하여 전송. 프레임에는 오류 메시지와 에러 코드(401)가 포함