### PR TITLE
feat: Redis Pub/Sub을 이용한 실시간 메시지 브로드캐스팅 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisListenerConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisListenerConfig.kt
@@ -1,0 +1,34 @@
+package com.zunza.buythedip_kotlin.config
+
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.Channels
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.RedisMessageSubscriber
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.data.redis.connection.RedisConnectionFactory
+import org.springframework.data.redis.listener.ChannelTopic
+import org.springframework.data.redis.listener.RedisMessageListenerContainer
+import org.springframework.data.redis.listener.adapter.MessageListenerAdapter
+
+@Configuration
+class RedisListenerConfig(
+    private val subscriber: RedisMessageSubscriber,
+    private val redisConnectionFactory: RedisConnectionFactory
+) {
+    @Bean
+    fun chatChannelTopic(): ChannelTopic {
+        return ChannelTopic(Channels.CHAT_CHANNEL.topic)
+    }
+
+    @Bean
+    fun listenerAdapter(): MessageListenerAdapter {
+        return MessageListenerAdapter(subscriber, "sendMessage")
+    }
+
+    @Bean
+    fun container(): RedisMessageListenerContainer {
+        val container = RedisMessageListenerContainer()
+        container.setConnectionFactory(redisConnectionFactory)
+        container.addMessageListener(listenerAdapter(), chatChannelTopic())
+        return container
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/Channels.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/Channels.kt
@@ -1,0 +1,8 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub
+
+
+enum class Channels(
+    val topic: String,
+) {
+    CHAT_CHANNEL("chat:message")
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/RedisMessagePublisher.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/RedisMessagePublisher.kt
@@ -1,0 +1,13 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub
+
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+
+@Service
+class RedisMessagePublisher(
+    private val redisTemplate: RedisTemplate<String, Any>
+) {
+    fun publishMessage(topic: String, message: Any) {
+        redisTemplate.convertAndSend(topic, message)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/RedisMessageSubscriber.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/RedisMessageSubscriber.kt
@@ -1,0 +1,34 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub
+
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.Channels.*
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.ChatHandler
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.RedisMessageHandler
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {  }
+
+@Service
+class RedisMessageSubscriber(
+    private val chatHandler: ChatHandler
+) {
+    fun sendMessage(message: String, channel: String) {
+        val handler = getHandler(channel)
+        if (handler == null) {
+            logger.warn { "Handler not found for channel: $channel" }
+            return
+        }
+
+        handler.handle(message)
+    }
+
+
+    private fun getHandler(channel: String): RedisMessageHandler? {
+        return when (channel) {
+            CHAT_CHANNEL.topic -> chatHandler
+            else -> null
+        }
+    }
+}
+
+

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/ChatHandler.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/ChatHandler.kt
@@ -1,0 +1,18 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zunza.buythedip_kotlin.chat.dto.ChatMessageDto
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+import org.springframework.stereotype.Component
+
+@Component
+class ChatHandler(
+    private val objectMapper: ObjectMapper,
+    private val messagingTemplate: SimpMessageSendingOperations
+) : RedisMessageHandler {
+
+    override fun handle(message: String) {
+        val chatMessageDto = objectMapper.readValue(message, ChatMessageDto::class.java)
+        messagingTemplate.convertAndSend("/topic/chat/room/public", chatMessageDto)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/RedisMessageHandler.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/RedisMessageHandler.kt
@@ -1,0 +1,5 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler
+
+interface RedisMessageHandler {
+    fun handle(message: String)
+}


### PR DESCRIPTION
1. 메시지 발행 (RedisMessagePublisher)
- publishMessage(topic, message) 메서드를 호출하면, 내부적으로 RedisTemplate.convertAndSend()를 통해 지정된 토픽(채널)으로 메시지를 발행

2. 메시지 수신 및 리스닝 (RedisListenerConfig)
- MessageListenerAdapter를 통해, 특정 채널에서 메시지가 수신되면 지정된 RedisMessageSubscriber의 sendMessage 메서드가 호출되도록 연결

3. 메시지 라우팅 및 처리 (RedisMessageSubscriber & *Handler)
- sendMessage 메서드는 수신된 메시지의 채널(토픽) 이름을 확인하고, 해당 채널을 처리할 적절한 Handler에게 작업을 위임
- ChatHandler와 같은 구현체는, 최종적으로 메시지를 파싱하여 SimpMessageSendingOperations를 통해 WebSocket 클라이언트에게 전달