### PR TITLE
feat: 실시간 채팅 시스템 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/chat/controller/ChatController.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/chat/controller/ChatController.kt
@@ -1,0 +1,24 @@
+package com.zunza.buythedip_kotlin.chat.controller
+
+import com.zunza.buythedip_kotlin.chat.dto.ChatMessageDto
+import com.zunza.buythedip_kotlin.chat.service.ChatService
+import com.zunza.buythedip_kotlin.security.user.CustomUserDetails
+import org.springframework.messaging.handler.annotation.MessageMapping
+import org.springframework.security.core.Authentication
+import org.springframework.web.bind.annotation.RestController
+import java.security.Principal
+
+@RestController
+class ChatController(
+    private val chatService: ChatService
+) {
+    @MessageMapping("/chat/room/public")
+    fun sendMessage(
+        chatMessage: ChatMessageDto,
+        principal: Principal
+    ) {
+        val authentication = principal as Authentication
+        val details = authentication.principal as CustomUserDetails
+        chatService.sendMessage(details.getUserId(), chatMessage)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/chat/dto/ChatMessageDto.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/chat/dto/ChatMessageDto.kt
@@ -1,0 +1,19 @@
+package com.zunza.buythedip_kotlin.chat.dto
+
+import java.time.LocalDateTime
+
+data class ChatMessageDto(
+    val sender: String,
+    val content: String,
+    val timestamp: Long
+) {
+    fun convertToMap(userId: Long): Map<String, String> {
+        return mapOf(
+            "userId" to userId.toString(),
+            "sender" to this.sender,
+            "content" to this.content,
+            "timestamp" to this.timestamp.toString()
+        )
+    }
+}
+

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/chat/entity/ChatMessage.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/chat/entity/ChatMessage.kt
@@ -1,0 +1,27 @@
+package com.zunza.buythedip_kotlin.chat.entity
+
+import jakarta.persistence.Id
+import org.springframework.data.mongodb.core.mapping.Document
+
+@Document(collection = "chat_messages")
+class ChatMessage(
+    @Id
+    val id: String? = null,
+    val userId: String,
+    val sender: String,
+    val content: String,
+    val timestamp: Long
+) {
+    companion object {
+        fun createOf(
+            userId: String, sender: String, content: String, timestamp: String
+        ): ChatMessage {
+            return ChatMessage(
+                userId = userId,
+                sender = sender,
+                content = content,
+                timestamp = timestamp.toLong()
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/chat/repository/ChatMessageRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/chat/repository/ChatMessageRepository.kt
@@ -1,0 +1,9 @@
+package com.zunza.buythedip_kotlin.chat.repository
+
+import com.zunza.buythedip_kotlin.chat.entity.ChatMessage
+import org.springframework.data.mongodb.repository.MongoRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface ChatMessageRepository : MongoRepository<ChatMessage, String> {
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/chat/scheduler/ChatMessageScheduler.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/chat/scheduler/ChatMessageScheduler.kt
@@ -1,0 +1,23 @@
+package com.zunza.buythedip_kotlin.chat.scheduler
+
+import com.zunza.buythedip_kotlin.chat.service.ChatMessageStreamConsumer
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+
+@Service
+class ChatMessageScheduler(
+    private val chatMessageStreamConsumer: ChatMessageStreamConsumer
+) {
+
+    @Scheduled(fixedDelay = 10_000)
+    @SchedulerLock(
+        name = "ChatMessageScheduler_processBatch()",
+        lockAtMostFor = "8s",
+        lockAtLeastFor = "2s"
+    )
+    fun processBatch() {
+        chatMessageStreamConsumer.consumeAndStore()
+    }
+}
+

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/chat/service/ChatMessageStreamConsumer.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/chat/service/ChatMessageStreamConsumer.kt
@@ -1,0 +1,75 @@
+package com.zunza.buythedip_kotlin.chat.service
+
+import com.zunza.buythedip_kotlin.chat.entity.ChatMessage
+import com.zunza.buythedip_kotlin.infrastructure.redis.RedisKey.*
+import com.zunza.buythedip_kotlin.infrastructure.redis.stream.RedisStreamService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import jakarta.annotation.PostConstruct
+import org.springframework.data.mongodb.core.MongoTemplate
+import org.springframework.data.redis.connection.stream.MapRecord
+import org.springframework.data.redis.connection.stream.RecordId
+import org.springframework.data.redis.connection.stream.StreamReadOptions
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.util.*
+
+private val logger = KotlinLogging.logger {  }
+
+@Service
+class ChatMessageStreamConsumer(
+    private val mongoTemplate: MongoTemplate,
+    private val redisStreamService: RedisStreamService
+) {
+    companion object {
+        private const val GROUP_NAME = "CHAT-GROUP"
+        private val CONSUMER_NAME: String = "server-${UUID.randomUUID()}"
+    }
+
+    @PostConstruct
+    fun init() {
+        try {
+            redisStreamService.createGroup(CHAT_MESSAGE_STREAM_KEY.value, GROUP_NAME)
+        } catch (e: Exception) {
+            logger.info { "Consumer group $GROUP_NAME already exists." }
+        }
+    }
+
+    fun consumeAndStore() {
+        val readOptions = StreamReadOptions.empty()
+            .count(200)
+            .block(Duration.ofSeconds(2L))
+
+        val mapRecords: List<MapRecord<String, String, String>> =  redisStreamService.read(
+            GROUP_NAME,
+            CONSUMER_NAME,
+            readOptions,
+            CHAT_MESSAGE_STREAM_KEY.value
+        )
+
+        if (mapRecords.isEmpty()) return
+
+        mongoTemplate.insertAll(convertToDocuments(mapRecords))
+        redisStreamService.ack(
+                CHAT_MESSAGE_STREAM_KEY.value,
+                GROUP_NAME,
+                *extractRecordIds(mapRecords))
+    }
+
+    private fun extractRecordIds(mapRecords: List<MapRecord<String, String, String>>): Array<RecordId> {
+        return mapRecords.map { it.id }
+            .toTypedArray()
+    }
+
+
+    private fun convertToDocuments(messages: List<MapRecord<String, String, String>>): List<ChatMessage> {
+        return messages.map { message ->
+            val value: Map<String, String> = message.value
+            ChatMessage.createOf(
+                value["userId"]!!,
+                value["sender"]!!,
+                value["content"]!!,
+                value["timestamp"]!!
+            )
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/chat/service/ChatService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/chat/service/ChatService.kt
@@ -1,0 +1,19 @@
+package com.zunza.buythedip_kotlin.chat.service
+
+import com.zunza.buythedip_kotlin.chat.dto.ChatMessageDto
+import com.zunza.buythedip_kotlin.infrastructure.redis.RedisKey.*
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.Channels
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.RedisMessagePublisher
+import com.zunza.buythedip_kotlin.infrastructure.redis.stream.RedisStreamService
+import org.springframework.stereotype.Service
+
+@Service
+class ChatService(
+    private val redisMessagePublisher: RedisMessagePublisher,
+    private val redisStreamService: RedisStreamService
+) {
+    fun sendMessage(userId: Long, chatMessage: ChatMessageDto) {
+        redisMessagePublisher.publishMessage(Channels.CHAT_CHANNEL.topic, chatMessage)
+        redisStreamService.addToStream(CHAT_MESSAGE_STREAM_KEY.value, chatMessage.convertToMap(userId))
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/RedisKey.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/RedisKey.kt
@@ -3,5 +3,6 @@ package com.zunza.buythedip_kotlin.infrastructure.redis
 enum class RedisKey(
     val value: String
 ) {
-    REFRESH_TOKEN_KEY_PREFIX("RT:");
+    REFRESH_TOKEN_KEY_PREFIX("RT:"),
+    CHAT_MESSAGE_STREAM_KEY("CHAT:STREAM"),
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/stream/RedisStreamService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/stream/RedisStreamService.kt
@@ -1,0 +1,45 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis.stream
+
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.redis.connection.stream.Consumer
+import org.springframework.data.redis.connection.stream.MapRecord
+import org.springframework.data.redis.connection.stream.ReadOffset
+import org.springframework.data.redis.connection.stream.RecordId
+import org.springframework.data.redis.connection.stream.StreamOffset
+import org.springframework.data.redis.connection.stream.StreamReadOptions
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+
+private val logger = KotlinLogging.logger {  }
+
+@Service
+class RedisStreamService(
+    private val redisTemplate: RedisTemplate<String, Any>
+) {
+    fun addToStream(key: String, fields: Map<String, String>) {
+        redisTemplate.opsForStream<String, String>().add(key, fields)
+    }
+
+    fun createGroup(key: String, group: String) {
+        redisTemplate.opsForStream<String, String>()
+            .createGroup(key, ReadOffset.from("0"), group)
+    }
+
+    fun read(
+        group: String,
+        consumer: String,
+        readOptions: StreamReadOptions,
+        key: String
+    ): List<MapRecord<String, String, String>> {
+        return redisTemplate.opsForStream<String, String>().read(
+            Consumer.from(group, consumer),
+            readOptions,
+            StreamOffset.create(key, ReadOffset.lastConsumed())
+        ) ?: emptyList()
+    }
+
+
+    fun ack(key: String, group: String, vararg recordIds: RecordId) {
+        redisTemplate.opsForStream<String, String>().acknowledge(key, group, *recordIds)
+    }
+}


### PR DESCRIPTION
1. 실시간 메시지 전송 파이프라인
- ChatController: @MessageMapping을 통해 WebSocket 클라이언트로부터 채팅 메시지를 수신하고, 인증된 사용자 정보를 추출하여 ChatService로 전달
- ChatService: 수신된 메시지를 Redis Pub/Sub 채널로 발행. 이 메시지는 chat 채널을 구독하고 있는 모든 서버 인스턴스에 실시간으로 전파되고, WebSocket 클라이언트들에게 브로드캐스팅

2. 채팅 데이터 저장
- ChatService: 메시지를 Pub/Sub으로 발행하는 동시에, 동일한 메시지를 Redis Streams에 추가(XADD).
- ChatMessageScheduler: @Scheduled를 통해 주기적으로 배치 작업을 트리거. @SchedulerLock을 사용하여 다중 인스턴스 환경에서도 이 작업이 단 한 번만 실행되도록 보장
- ChatMessageStreamConsumer: 스케줄러에 의해 호출되면, Redis Streams의 Consumer Group을 통해 아직 처리되지 않은 메시지들을 배치크기만큼 읽어옴.
- 읽어온 메시지들을 ChatMessage Document로 변환하여, MongoTemplate.insertAll()을 통해 MongoDB에 한 번의 쿼리로 저장
- 저장이 완료되면, 처리된 메시지들의 ID를 Redis에 ACK하여 중복 처리를 방지