### PR TITLE
feat: 실시간 거래대금 기준 상위 50개 암호화폐 랭킹 시스템 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisCacheConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisCacheConfig.kt
@@ -1,6 +1,6 @@
 package com.zunza.buythedip_kotlin.config
 
-import com.zunza.buythedip_kotlin.infrastructure.redis.CacheType
+import com.zunza.buythedip_kotlin.infrastructure.redis.constants.CacheType
 import org.springframework.cache.CacheManager
 import org.springframework.cache.annotation.EnableCaching
 import org.springframework.context.annotation.Bean

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisListenerConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisListenerConfig.kt
@@ -20,6 +20,17 @@ class RedisListenerConfig(
     }
 
     @Bean
+    fun topVolumeTickerSummaryChannelTopic(): ChannelTopic {
+        return ChannelTopic(Channels.TOP_VOLUME_TICKER_SUMMARY_CHANNEL.topic)
+    }
+
+    @Bean
+    fun topVolumeTickerPriceChannelTopic(): ChannelTopic {
+        return ChannelTopic(Channels.TOP_VOLUME_TICKER_PRICE_CHANNEL.topic)
+    }
+
+
+    @Bean
     fun listenerAdapter(): MessageListenerAdapter {
         return MessageListenerAdapter(subscriber, "sendMessage")
     }
@@ -29,6 +40,8 @@ class RedisListenerConfig(
         val container = RedisMessageListenerContainer()
         container.setConnectionFactory(redisConnectionFactory)
         container.addMessageListener(listenerAdapter(), chatChannelTopic())
+        container.addMessageListener(listenerAdapter(), topVolumeTickerSummaryChannelTopic())
+        container.addMessageListener(listenerAdapter(), topVolumeTickerPriceChannelTopic())
         return container
     }
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebClientConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebClientConfig.kt
@@ -1,0 +1,17 @@
+package com.zunza.buythedip_kotlin.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.http.HttpHeaders
+import org.springframework.http.MediaType
+import org.springframework.web.reactive.function.client.WebClient
+
+@Configuration
+class WebClientConfig {
+
+    @Bean
+    fun webClientBuilder(): WebClient.Builder {
+        return WebClient.builder()
+            .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebSocketClientConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebSocketClientConfig.kt
@@ -1,0 +1,15 @@
+package com.zunza.buythedip_kotlin.config
+
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.web.socket.client.WebSocketClient
+import org.springframework.web.socket.client.standard.StandardWebSocketClient
+
+@Configuration
+class WebSocketClientConfig {
+
+    @Bean
+    fun webSocketClient(): WebSocketClient {
+        return StandardWebSocketClient()
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebSocketConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/WebSocketConfig.kt
@@ -19,7 +19,7 @@ class WebSocketConfig(
 
     override fun registerStompEndpoints(registry: StompEndpointRegistry) {
         registry.setErrorHandler(StompExceptionHandler())
-        registry.addEndpoint("/ws/chat")
+        registry.addEndpoint("/ws/chat", "/ws/market")
             .addInterceptors(WebSocketHandShakeInterceptor())
             .setAllowedOriginPatterns("*")
             .withSockJS()

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/client/TradeWebSocketClient.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/client/TradeWebSocketClient.kt
@@ -1,0 +1,71 @@
+package com.zunza.buythedip_kotlin.crypto.binance.stream.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zunza.buythedip_kotlin.crypto.dto.SubscribeRequest
+import com.zunza.buythedip_kotlin.crypto.dto.TradeStreamResponse
+import com.zunza.buythedip_kotlin.crypto.repository.CryptoRepository
+import com.zunza.buythedip_kotlin.crypto.service.CryptoMarketDataService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import kotlinx.coroutines.launch
+import kotlinx.coroutines.runBlocking
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import org.springframework.web.socket.client.WebSocketClient
+import org.springframework.web.socket.handler.TextWebSocketHandler
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class TradeWebSocketClient(
+    private val webSocketClient: WebSocketClient,
+    private val cryptoRepository: CryptoRepository,
+    private val objectMapper: ObjectMapper,
+    private val cryptoMarketDataService: CryptoMarketDataService
+) : TextWebSocketHandler() {
+
+    companion object {
+        private const val URL = "wss://data-stream.binance.vision/stream"
+        private const val STREAM_SUFFIX = "usdt@trade"
+    }
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun connect() {
+        try {
+            webSocketClient.execute(this, URL)
+            logger.info { "Binance WebSocket Connected.. Type: [TRADE]" }
+        } catch (e: Exception) {
+            logger.warn { e.message }
+        }
+    }
+
+    override fun afterConnectionEstablished(session: WebSocketSession) {
+        val symbols: List<String> = cryptoRepository.findAll()
+            .map { crypto -> crypto.symbol.lowercase() + STREAM_SUFFIX }
+
+        val payload = objectMapper.writeValueAsString(SubscribeRequest(
+            "SUBSCRIBE",
+            symbols,
+            session.id
+        ))
+
+        session.sendMessage(TextMessage(payload))
+    }
+
+    override fun handleTextMessage(
+        session: WebSocketSession,
+        message: TextMessage
+    ):Unit = runBlocking {
+        val tradeStreamResponse = objectMapper.readValue(
+            message.payload,
+            TradeStreamResponse::class.java
+        )
+
+        val tradeData = tradeStreamResponse.tradeData ?: return@runBlocking
+
+        launch { cryptoMarketDataService.accumulateMinuteTickerVolume(tradeData) }
+        launch { cryptoMarketDataService.publishTopNTickerPrice(tradeData) }
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/converter/StringListConverter.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/converter/StringListConverter.kt
@@ -1,0 +1,37 @@
+package com.zunza.buythedip_kotlin.crypto.converter
+
+import com.fasterxml.jackson.core.JsonProcessingException
+import com.fasterxml.jackson.core.type.TypeReference
+import com.fasterxml.jackson.databind.ObjectMapper
+import jakarta.persistence.AttributeConverter
+import jakarta.persistence.Converter
+
+@Converter
+class StringListConverter(
+    private val objectMapper: ObjectMapper
+) : AttributeConverter<List<String>, String> {
+    override fun convertToDatabaseColumn(p0: List<String>?): String? {
+        if (p0 == null || p0.isEmpty()) {
+            return null
+        }
+
+        try {
+            return objectMapper.writeValueAsString(p0)
+        } catch (e: JsonProcessingException) {
+            throw RuntimeException("List to JSON conversion failed", e)
+        }
+    }
+
+    override fun convertToEntityAttribute(p0: String?): List<String>? {
+        if (p0 == null || p0.isEmpty()) {
+            return emptyList()
+        }
+
+        try {
+            return objectMapper.readValue(p0, object : TypeReference<List<String>>() {})
+        } catch (e: JsonProcessingException) {
+            throw RuntimeException("JSON to List conversion failed", e)
+        }
+    }
+}
+

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/CryptoWithLogoDto.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/CryptoWithLogoDto.kt
@@ -1,0 +1,8 @@
+package com.zunza.buythedip_kotlin.crypto.dto
+
+data class CryptoWithLogoDto(
+    val id: Long = 0,
+    val name: String = "",
+    val symbol: String = "",
+    val logo: String = ""
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/SubscribeRequest.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/SubscribeRequest.kt
@@ -1,0 +1,7 @@
+package com.zunza.buythedip_kotlin.crypto.dto
+
+data class SubscribeRequest(
+    val method: String,
+    val params: List<String>,
+    val id: String
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/TopVolumeTickerPriceResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/TopVolumeTickerPriceResponse.kt
@@ -1,0 +1,7 @@
+package com.zunza.buythedip_kotlin.crypto.dto
+
+data class TopVolumeTickerPriceResponse(
+    val symbol: String,
+    val currentPrice: Double,
+    val changeRate: Double
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/TopVolumeTickerSummaryResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/TopVolumeTickerSummaryResponse.kt
@@ -1,0 +1,9 @@
+package com.zunza.buythedip_kotlin.crypto.dto
+
+data class TopVolumeTickerSummaryResponse(
+    val id: Long,
+    val name: String,
+    val symbol: String,
+    val logo: String,
+    val volume: Double
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/TradeStreamResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/TradeStreamResponse.kt
@@ -1,0 +1,27 @@
+package com.zunza.buythedip_kotlin.crypto.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class TradeStreamResponse(
+
+    @JsonProperty("data")
+    val tradeData: TradeData?
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+class TradeData(
+
+    @JsonProperty("s")
+    val symbol: String,
+
+    @JsonProperty("p")
+    val price: Double,
+
+    @JsonProperty("q")
+    val quantity: Double,
+
+    @JsonProperty("T")
+    val tradeTime: Long
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/entity/Crypto.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/entity/Crypto.kt
@@ -1,0 +1,41 @@
+package com.zunza.buythedip_kotlin.crypto.entity
+
+import jakarta.persistence.CascadeType
+import jakarta.persistence.Entity
+import jakarta.persistence.EntityListeners
+import jakarta.persistence.FetchType
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.JoinColumn
+import jakarta.persistence.OneToOne
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class Crypto(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    val name: String,
+
+    val symbol: String,
+
+    val status: String,
+
+    @CreationTimestamp
+    val createdAt: LocalDateTime,
+
+    @UpdateTimestamp
+    val updatedAt: LocalDateTime,
+
+    @OneToOne(cascade = [CascadeType.ALL], orphanRemoval = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "metadata_id")
+    val metadata: CryptoMetadata
+) {
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/entity/CryptoMetadata.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/entity/CryptoMetadata.kt
@@ -1,0 +1,49 @@
+package com.zunza.buythedip_kotlin.crypto.entity
+
+import com.zunza.buythedip_kotlin.crypto.converter.StringListConverter
+import jakarta.persistence.*
+import org.hibernate.annotations.CreationTimestamp
+import org.hibernate.annotations.UpdateTimestamp
+import org.springframework.data.jpa.domain.support.AuditingEntityListener
+import java.time.LocalDateTime
+
+@Entity
+@EntityListeners(AuditingEntityListener::class)
+class CryptoMetadata(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0,
+
+    val logo: String,
+
+    @Lob
+    @Column(columnDefinition = "TEXT")
+    val description: String,
+
+    @Column(columnDefinition = "TEXT")
+    @Convert(converter = StringListConverter::class)
+    val website: List<String>,
+
+    @Column(columnDefinition = "TEXT")
+    @Convert(converter = StringListConverter::class)
+    val twitter: List<String>,
+
+    @Column(columnDefinition = "TEXT")
+    @Convert(converter = StringListConverter::class)
+    val explorer: List<String>,
+
+    @Column(columnDefinition = "TEXT")
+    @Convert(converter = StringListConverter::class)
+    val tagNames: List<String>,
+
+    @CreationTimestamp
+    val createdAt: LocalDateTime,
+
+    @UpdateTimestamp
+    val updatedAt: LocalDateTime,
+
+    @OneToOne
+    @JoinColumn(name = "crypto_id")
+    val crypto: Crypto
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoMarketDataRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoMarketDataRepository.kt
@@ -2,7 +2,9 @@ package com.zunza.buythedip_kotlin.crypto.repository
 
 import com.zunza.buythedip_kotlin.infrastructure.redis.constants.RedisKey.*
 import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.data.redis.core.ZSetOperations
 import org.springframework.stereotype.Component
+import java.time.Duration
 
 @Component
 class CryptoMarketDataRepository(
@@ -10,5 +12,34 @@ class CryptoMarketDataRepository(
 ) {
     fun saveOpenPrice(symbol: String, openPrice: Double) {
         redisTemplate.opsForValue().set(OPEN_PRICE_KEY_PREFIX.value + symbol, openPrice)
+    }
+
+    fun findOpenPriceBySymbol(symbol: String): Double {
+        return redisTemplate.opsForValue().get(OPEN_PRICE_KEY_PREFIX.value + symbol) as Double
+    }
+
+    fun saveVolumeByMinute(key: String, symbol: String, volume: Double, ttl: Long) {
+        redisTemplate.opsForZSet().incrementScore(key, symbol, volume)
+        redisTemplate.expire(key, Duration.ofMinutes(ttl))
+    }
+
+    fun aggregateVolume(keys: List<String>, targetKey: String) {
+        redisTemplate.opsForZSet().unionAndStore(keys.first(), keys.drop(1), targetKey)
+    }
+
+    fun findTopNTickers(n: Long): Set<ZSetOperations.TypedTuple<Any>>? {
+        return redisTemplate.opsForZSet().reverseRangeWithScores(
+            AGGREGATED_VOLUME_KEY.value,
+            0,
+            n - 1)
+    }
+
+    fun updateTopVolumeSymbols(symbols: Set<String>) {
+        redisTemplate.opsForValue().set(TOP_VOLUME_SYMBOLS_KEY.value, symbols)
+    }
+
+    fun findTopVolumeSymbols(): Set<String> {
+        val result = redisTemplate.opsForValue().get(TOP_VOLUME_SYMBOLS_KEY.value)
+        return result as? Set<String> ?: emptySet()
     }
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoMetadataRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoMetadataRepository.kt
@@ -1,0 +1,9 @@
+package com.zunza.buythedip_kotlin.crypto.repository
+
+import com.zunza.buythedip_kotlin.crypto.entity.CryptoMetadata
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CryptoMetadataRepository : JpaRepository<CryptoMetadata, Long> {
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoRepository.kt
@@ -1,0 +1,25 @@
+package com.zunza.buythedip_kotlin.crypto.repository
+
+import com.zunza.buythedip_kotlin.crypto.dto.CryptoWithLogoDto
+import com.zunza.buythedip_kotlin.crypto.entity.Crypto
+import org.springframework.cache.annotation.Cacheable
+import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.stereotype.Repository
+
+@Repository
+interface CryptoRepository : JpaRepository<Crypto, Long> {
+
+    @Query("""
+        SELECT new com.zunza.buythedip_kotlin.crypto.dto.CryptoWithLogoDto(
+        c.id,
+        c.name,
+        c.symbol,
+        m.logo
+        )
+        FROM Crypto c
+        JOIN c.metadata m
+        """)
+    @Cacheable(cacheNames = ["CRYPTO:WITH:LOGO"])
+    fun findAllWithLogo(): List<CryptoWithLogoDto>
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/scheduler/CryptoMarketDataScheduler.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/scheduler/CryptoMarketDataScheduler.kt
@@ -45,4 +45,21 @@ fun updateDailyOpenPrice() {
             logger.warn { e.message }
         }
     }
+
+    // TODO: 초기 데이터
+    @Scheduled(cron = "0/10 * * * * *")
+    @SchedulerLock(
+        name = "CryptoMarketDataScheduler_updateTickerVolume"
+    )
+    fun updateTickerVolume() {
+        cryptoMarketDataService.aggregateTickerVolumesInRange(AGGREGATION_WINDOW_MINUTE)
+        val tickers = cryptoMarketDataService.getTopNTickersByVolume(TOP_N)
+
+        if (tickers.isNullOrEmpty()) {
+            return
+        }
+
+        cryptoMarketDataService.cacheTopNTickerSymbols(tickers)
+        cryptoMarketDataService.publishTopNTickerSummaries(tickers)
+    }
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/service/CryptoMarketDataService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/service/CryptoMarketDataService.kt
@@ -1,14 +1,30 @@
 package com.zunza.buythedip_kotlin.crypto.service
 
+import com.zunza.buythedip_kotlin.crypto.dto.CryptoWithLogoDto
+import com.zunza.buythedip_kotlin.crypto.dto.TopVolumeTickerPriceResponse
+import com.zunza.buythedip_kotlin.crypto.dto.TopVolumeTickerSummaryResponse
+import com.zunza.buythedip_kotlin.crypto.dto.TradeData
 import com.zunza.buythedip_kotlin.crypto.repository.CryptoMarketDataRepository
+import com.zunza.buythedip_kotlin.crypto.repository.CryptoRepository
+import com.zunza.buythedip_kotlin.infrastructure.redis.constants.RedisKey.*
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.Channels
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.RedisMessagePublisher
 import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.data.redis.core.ZSetOperations
 import org.springframework.stereotype.Service
+import java.time.Instant
+import java.time.LocalDateTime
+import java.time.ZoneId
+import java.time.format.DateTimeFormatter
+import java.time.temporal.ChronoUnit
 
 private val logger = KotlinLogging.logger {  }
 
 @Service
 class CryptoMarketDataService(
     private val cryptoMarketDataRepository: CryptoMarketDataRepository,
+    private val cryptoRepository: CryptoRepository,
+    private val redisMessagePublisher: RedisMessagePublisher
 ) {
     companion object {
         private const val ZONE_ID = "UTC"
@@ -18,4 +34,106 @@ class CryptoMarketDataService(
     fun updateOpenPrice(symbol: String, openPrice: Double) {
         cryptoMarketDataRepository.saveOpenPrice(symbol, openPrice)
     }
+
+    fun accumulateMinuteTickerVolume(tradeData: TradeData) {
+        cryptoMarketDataRepository.saveVolumeByMinute(
+            generateCurrentMinuteBucketKey(tradeData.tradeTime),
+            tradeData.symbol,
+            tradeData.price * tradeData.quantity,
+            BUCKET_TTL_MINUTE
+        )
+    }
+
+    fun aggregateTickerVolumesInRange(range: Int) {
+        val keys = generateKeysForLastNMinutes(range)
+        cryptoMarketDataRepository.aggregateVolume(keys, AGGREGATED_VOLUME_KEY.value)
+    }
+
+    fun getTopNTickersByVolume(n: Long): Set<ZSetOperations.TypedTuple<Any>>? {
+        return cryptoMarketDataRepository.findTopNTickers(n)
+    }
+
+    fun cacheTopNTickerSymbols(tickers: Set<ZSetOperations.TypedTuple<Any>>) {
+        val symbols = tickers.map { ticker -> ticker.value.toString() }.toSet()
+        cryptoMarketDataRepository.updateTopVolumeSymbols(symbols)
+    }
+
+
+    fun publishTopNTickerSummaries(tickers: Set<ZSetOperations.TypedTuple<Any>>) {
+        val cryptoMap: Map<String, CryptoWithLogoDto> = cryptoRepository.findAllWithLogo()
+            .associateBy { cryptoWithLogoDto -> cryptoWithLogoDto.symbol }
+
+        redisMessagePublisher.publishMessage(
+            Channels.TOP_VOLUME_TICKER_SUMMARY_CHANNEL.topic,
+            convertToTopVolumeTickerSummaryResponse(cryptoMap, tickers)
+        )
+    }
+
+    fun publishTopNTickerPrice(tradeData: TradeData) {
+        val symbols = cryptoMarketDataRepository.findTopVolumeSymbols()
+
+        if (tradeData.symbol in symbols) {
+            redisMessagePublisher.publishMessage(
+                Channels.TOP_VOLUME_TICKER_PRICE_CHANNEL.topic,
+                convertToTopVolumeTickerPriceResponse(
+                    tradeData.symbol,
+                    tradeData.price
+                )
+            )
+        }
+    }
+
+    private fun generateCurrentMinuteBucketKey(tradeTime: Long): String {
+        val tradeDateTime = LocalDateTime.ofInstant(
+            Instant.ofEpochMilli(tradeTime),
+            ZoneId.of(ZONE_ID)
+        )
+
+        return MINUTE_BUCKET_KEY_PREFIX.value + tradeDateTime.format(
+            DateTimeFormatter.ofPattern("yyyyMMddHHmm")
+        )
+    }
+
+    private fun generateKeysForLastNMinutes(minutes: Int): List<String> {
+        val now = Instant.now()
+        return (0 until minutes).map { i ->
+            val time = now.minus(i.toLong(), ChronoUnit.MINUTES).toEpochMilli()
+            generateCurrentMinuteBucketKey(time)
+        }
+    }
+
+    private fun convertToTopVolumeTickerSummaryResponse(
+        cryptoMap: Map<String, CryptoWithLogoDto>,
+        tickers: Set<ZSetOperations.TypedTuple<Any>>
+    ): List<TopVolumeTickerSummaryResponse> {
+        return tickers.map { ticker ->
+            val symbol = extractOriginalSymbol(ticker.value.toString())
+            val cryptoWithLogo = cryptoMap[symbol]
+
+            TopVolumeTickerSummaryResponse(
+                cryptoWithLogo!!.id,
+                cryptoWithLogo.name,
+                cryptoWithLogo.symbol,
+                cryptoWithLogo.logo,
+                ticker.score!!
+            )
+        }
+    }
+
+    private fun convertToTopVolumeTickerPriceResponse(
+        symbol: String,
+        currentPrice: Double
+    ): TopVolumeTickerPriceResponse {
+        val originalSymbol = extractOriginalSymbol(symbol)
+        val openPrice = getOpenPrice(symbol)
+        val changeRate = getChangeRate(currentPrice, openPrice)
+
+        return TopVolumeTickerPriceResponse(originalSymbol, currentPrice, changeRate)
+    }
+
+    private fun extractOriginalSymbol(symbol: String) = symbol.removeSuffix("USDT")
+
+    private fun getOpenPrice(symbol: String) = cryptoMarketDataRepository.findOpenPriceBySymbol(symbol)
+
+    private fun getChangeRate(currentPrice: Double, openPrice: Double) = ((currentPrice - openPrice) / openPrice) * 100;
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/service/CryptoService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/service/CryptoService.kt
@@ -1,0 +1,11 @@
+package com.zunza.buythedip_kotlin.crypto.service
+
+import com.zunza.buythedip_kotlin.crypto.repository.CryptoRepository
+import org.springframework.stereotype.Service
+
+@Service
+class CryptoService(
+    private val cryptoRepository: CryptoRepository
+) {
+    fun getAllCrypto() = cryptoRepository.findAll()
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/constants/CacheType.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/constants/CacheType.kt
@@ -1,0 +1,12 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis.constants
+
+import java.time.Duration
+
+enum class CacheType(
+    val cacheName: String,
+    val ttl: Duration
+) {
+    NEWS_PAGE("NEWS:PAGE", Duration.ofMinutes(30)),
+    NEWS_DETAIL("NEWS:DETAIL", Duration.ofMinutes(10)),
+    CRYPTO_WITH_LOGO("CRYPTO:WITH:LOGO", Duration.ofMinutes(60))
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/constants/RedisKey.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/constants/RedisKey.kt
@@ -1,0 +1,12 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis.constants
+
+enum class RedisKey(
+    val value: String
+) {
+    REFRESH_TOKEN_KEY_PREFIX("RT:"),
+    CHAT_MESSAGE_STREAM_KEY("CHAT:STREAM"),
+    OPEN_PRICE_KEY_PREFIX("OPEN:PRICE:"),
+    MINUTE_BUCKET_KEY_PREFIX("tv:"),
+    AGGREGATED_VOLUME_KEY(MINUTE_BUCKET_KEY_PREFIX.value + "AGGREGATED"),
+    TOP_VOLUME_SYMBOLS_KEY("TOP:VOLUME:SYMBOLS")
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/Channels.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/Channels.kt
@@ -4,5 +4,7 @@ package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub
 enum class Channels(
     val topic: String,
 ) {
-    CHAT_CHANNEL("chat:message")
+    CHAT_CHANNEL("chat:message"),
+    TOP_VOLUME_TICKER_SUMMARY_CHANNEL("top:volume:ticker:summary"),
+    TOP_VOLUME_TICKER_PRICE_CHANNEL("top:volume:ticker:price")
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/RedisMessageSubscriber.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/RedisMessageSubscriber.kt
@@ -3,6 +3,8 @@ package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub
 import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.Channels.*
 import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.ChatHandler
 import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.RedisMessageHandler
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.TopVolumeTickerPriceHandler
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.TopVolumeTickerSummaryHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 
@@ -10,7 +12,9 @@ private val logger = KotlinLogging.logger {  }
 
 @Service
 class RedisMessageSubscriber(
-    private val chatHandler: ChatHandler
+    private val chatHandler: ChatHandler,
+    private val topVolumeTickerSummaryHandler: TopVolumeTickerSummaryHandler,
+    private val topVolumeTickerPriceHandler: TopVolumeTickerPriceHandler
 ) {
     fun sendMessage(message: String, channel: String) {
         val handler = getHandler(channel)
@@ -22,10 +26,11 @@ class RedisMessageSubscriber(
         handler.handle(message)
     }
 
-
     private fun getHandler(channel: String): RedisMessageHandler? {
         return when (channel) {
             CHAT_CHANNEL.topic -> chatHandler
+            TOP_VOLUME_TICKER_SUMMARY_CHANNEL.topic -> topVolumeTickerSummaryHandler
+            TOP_VOLUME_TICKER_PRICE_CHANNEL.topic -> topVolumeTickerPriceHandler
             else -> null
         }
     }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/TopVolumeTickerPriceHandler.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/TopVolumeTickerPriceHandler.kt
@@ -1,18 +1,21 @@
 package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.zunza.buythedip_kotlin.chat.dto.ChatMessageDto
+import com.zunza.buythedip_kotlin.crypto.dto.TopVolumeTickerPriceResponse
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.messaging.simp.SimpMessageSendingOperations
 import org.springframework.stereotype.Component
 
+private val logger = KotlinLogging.logger {  }
+
 @Component
-class ChatHandler(
+class TopVolumeTickerPriceHandler(
     private val objectMapper: ObjectMapper,
     private val messagingTemplate: SimpMessageSendingOperations
 ) : RedisMessageHandler {
 
     override fun handle(message: String) {
-        val response = objectMapper.readValue(message, ChatMessageDto::class.java)
-        messagingTemplate.convertAndSend("/topic/chat/room/public", response)
+        val response = objectMapper.readValue(message, TopVolumeTickerPriceResponse::class.java)
+        messagingTemplate.convertAndSend("/topic/crypto/top/volume/price", response)
     }
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/TopVolumeTickerSummaryHandler.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/TopVolumeTickerSummaryHandler.kt
@@ -1,18 +1,17 @@
 package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler
 
 import com.fasterxml.jackson.databind.ObjectMapper
-import com.zunza.buythedip_kotlin.chat.dto.ChatMessageDto
 import org.springframework.messaging.simp.SimpMessageSendingOperations
 import org.springframework.stereotype.Component
 
 @Component
-class ChatHandler(
+class TopVolumeTickerSummaryHandler(
     private val objectMapper: ObjectMapper,
     private val messagingTemplate: SimpMessageSendingOperations
 ) : RedisMessageHandler {
 
     override fun handle(message: String) {
-        val response = objectMapper.readValue(message, ChatMessageDto::class.java)
-        messagingTemplate.convertAndSend("/topic/chat/room/public", response)
+        val response = objectMapper.readValue(message, List::class.java)
+        messagingTemplate.convertAndSend("/topic/crypto/top/volume/summary", response)
     }
 }


### PR DESCRIPTION
바이낸스 WebSocket 스트림으로부터 수신되는 실시간 체결 데이터를 기반으로, 거래대금이 가장 높은 상위 50개 암호화폐를 동적으로 선정하고, 해당 종목들의 요약 정보와 실시간 가격 변동을 사용자에게 전송하는 실시간 데이터 파이프라인을 구축

1. 데이터 수집 및 분 단위 누적
- TradeWebSocketClient는 바이낸스로부터 모든 암호화폐(현물 기준)의 실시간 체결 데이터를 수신
- 수신된 각 체결 데이터에 대해, cryptoMarketDataService.accumulateMinuteTickerVolume를 호출
- 이 메서드는 ZINCRBY 명령을 사용하여, 현재 분에 해당하는 Redis ZSET 키(예: MINUTE_BUCKET:202501281030)에 각 암호화폐의 거래대금(price * quantity)을 누적

2. 스케줄링을 통한 주기적 집계 및 랭킹 산정
- 10초마다 @Scheduled와 @SchedulerLock으로 보호되는 배치 작업이 실행
- ZUNIONSTORE 명령을 사용하여, 최근 30분 동안의 모든 분 단위 거래대금들을 하나의 합산된 ZSET으로 통합
- 합산된 ZSET에서 ZREVRANGE 명령을 사용하여, 거래대금이 가장 높은 상위 50개 종목의 목록과 누적 거래대금을 추출

3. Top N 정보 브로드캐스팅
- 스케줄러는 10초마다 Top 50 종목 목록을 publishTopNTickerSummaries 메서드에 전달
- DB에서 각 종목의 메타데이터(한글 이름, 로고 등)를 가져와 결합한 후, /topic/crypto/top/volume/summary 토픽으로 전체 Top 50 요약 정보를 브로드캐스팅
- TradeWebSocketClient의 handleTextMessage는 체결 데이터를 수신할 때마다 publishTopNTickerPrice를 호출
- 현재 수신된 종목이 Top 50 목록에 포함되어 있는지 Redis에 캐싱된 목록(TOP_VOLUME_SYMBOLS)과 비교
- 포함되어 있을 경우에만, 해당 종목의 실시간 가격, 시가 대비 등락률 등의 정보를 계산하여 /topic/crypto/top/volume/price 토픽으로 발행