### PR TITLE
feat: 개별 암호화폐 실시간 시세 제공을 위한 데이터 파이프라인 추가

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisListenerConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisListenerConfig.kt
@@ -1,6 +1,6 @@
 package com.zunza.buythedip_kotlin.config
 
-import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.Channels
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.Channels.*
 import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.RedisMessageSubscriber
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
@@ -16,19 +16,23 @@ class RedisListenerConfig(
 ) {
     @Bean
     fun chatChannelTopic(): ChannelTopic {
-        return ChannelTopic(Channels.CHAT_CHANNEL.topic)
+        return ChannelTopic(CHAT_CHANNEL.topic)
     }
 
     @Bean
     fun topVolumeTickerSummaryChannelTopic(): ChannelTopic {
-        return ChannelTopic(Channels.TOP_VOLUME_TICKER_SUMMARY_CHANNEL.topic)
+        return ChannelTopic(TOP_VOLUME_TICKER_SUMMARY_CHANNEL.topic)
     }
 
     @Bean
     fun topVolumeTickerPriceChannelTopic(): ChannelTopic {
-        return ChannelTopic(Channels.TOP_VOLUME_TICKER_PRICE_CHANNEL.topic)
+        return ChannelTopic(TOP_VOLUME_TICKER_PRICE_CHANNEL.topic)
     }
 
+    @Bean
+    fun singleTickerPriceChannelTopic(): ChannelTopic {
+        return ChannelTopic(SINGLE_TICKER_PRICE_CHANNEL.topic)
+    }
 
     @Bean
     fun listenerAdapter(): MessageListenerAdapter {
@@ -42,6 +46,7 @@ class RedisListenerConfig(
         container.addMessageListener(listenerAdapter(), chatChannelTopic())
         container.addMessageListener(listenerAdapter(), topVolumeTickerSummaryChannelTopic())
         container.addMessageListener(listenerAdapter(), topVolumeTickerPriceChannelTopic())
+        container.addMessageListener(listenerAdapter(), singleTickerPriceChannelTopic())
         return container
     }
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/client/TradeWebSocketClient.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/client/TradeWebSocketClient.kt
@@ -67,5 +67,6 @@ class TradeWebSocketClient(
 
         launch { cryptoMarketDataService.accumulateMinuteTickerVolume(tradeData) }
         launch { cryptoMarketDataService.publishTopNTickerPrice(tradeData) }
+        launch { cryptoMarketDataService.publishSingleTickerPrice(tradeData) }
     }
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/SingleTickerPriceResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/SingleTickerPriceResponse.kt
@@ -1,0 +1,8 @@
+package com.zunza.buythedip_kotlin.crypto.dto
+
+data class SingleTickerPriceResponse(
+    val symbol: String,
+    val currentPrice: Double,
+    val changePrice: Double,
+    val changeRate: Double
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoMarketDataRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoMarketDataRepository.kt
@@ -15,7 +15,7 @@ class CryptoMarketDataRepository(
     }
 
     fun findOpenPriceBySymbol(symbol: String): Double {
-        return redisTemplate.opsForValue().get(OPEN_PRICE_KEY_PREFIX.value + symbol) as Double
+        return redisTemplate.opsForValue().get(OPEN_PRICE_KEY_PREFIX.value + symbol) as? Double ?: 0.0
     }
 
     fun saveVolumeByMinute(key: String, symbol: String, volume: Double, ttl: Long) {

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/Channels.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/Channels.kt
@@ -6,5 +6,6 @@ enum class Channels(
 ) {
     CHAT_CHANNEL("chat:message"),
     TOP_VOLUME_TICKER_SUMMARY_CHANNEL("top:volume:ticker:summary"),
-    TOP_VOLUME_TICKER_PRICE_CHANNEL("top:volume:ticker:price")
+    TOP_VOLUME_TICKER_PRICE_CHANNEL("top:volume:ticker:price"),
+    SINGLE_TICKER_PRICE_CHANNEL("single:ticker:price")
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/RedisMessageSubscriber.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/RedisMessageSubscriber.kt
@@ -1,8 +1,10 @@
 package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub
 
+import com.zunza.buythedip_kotlin.crypto.dto.TopVolumeTickerPriceResponse
 import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.Channels.*
 import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.ChatHandler
 import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.RedisMessageHandler
+import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.SingleTickerPriceHandler
 import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.TopVolumeTickerPriceHandler
 import com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler.TopVolumeTickerSummaryHandler
 import io.github.oshai.kotlinlogging.KotlinLogging
@@ -14,7 +16,8 @@ private val logger = KotlinLogging.logger {  }
 class RedisMessageSubscriber(
     private val chatHandler: ChatHandler,
     private val topVolumeTickerSummaryHandler: TopVolumeTickerSummaryHandler,
-    private val topVolumeTickerPriceHandler: TopVolumeTickerPriceHandler
+    private val topVolumeTickerPriceHandler: TopVolumeTickerPriceHandler,
+    private val singleTickerPriceHandler: SingleTickerPriceHandler
 ) {
     fun sendMessage(message: String, channel: String) {
         val handler = getHandler(channel)
@@ -31,6 +34,7 @@ class RedisMessageSubscriber(
             CHAT_CHANNEL.topic -> chatHandler
             TOP_VOLUME_TICKER_SUMMARY_CHANNEL.topic -> topVolumeTickerSummaryHandler
             TOP_VOLUME_TICKER_PRICE_CHANNEL.topic -> topVolumeTickerPriceHandler
+            SINGLE_TICKER_PRICE_CHANNEL.topic -> singleTickerPriceHandler
             else -> null
         }
     }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/SingleTickerPriceHandler.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/pub_sub/handler/SingleTickerPriceHandler.kt
@@ -1,0 +1,19 @@
+package com.zunza.buythedip_kotlin.infrastructure.redis.pub_sub.handler
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zunza.buythedip_kotlin.crypto.dto.SingleTickerPriceResponse
+import org.springframework.messaging.simp.SimpMessageSendingOperations
+import org.springframework.stereotype.Component
+
+
+@Component
+class SingleTickerPriceHandler(
+    private val objectMapper: ObjectMapper,
+    private val messagingTemplate: SimpMessageSendingOperations
+) : RedisMessageHandler {
+
+    override fun handle(message: String) {
+        val response = objectMapper.readValue(message, SingleTickerPriceResponse::class.java)
+        messagingTemplate.convertAndSend("/topic/crypto/price/${response.symbol}", response)
+    }
+}


### PR DESCRIPTION
사용자가 특정 암호화폐의 상세 페이지를 보고 있을 때 해당 종목의 가격 변동을 실시간으로 받아볼 수 있게 개별 시세 파이프 라인 구현

1. 데이터 처리 분기 (TradeWebSocketClient)
- 바이낸스로부터 실시간 체결 데이터를 수신하는 handleTextMessage 메서드 내부에, cryptoMarketDataService.publishSingleTickerPrice(tradeData)를 호출하는 새로운 코루틴을 추가
- 이제 수신된 모든 체결 데이터는 기존의 거래대금 누적, Top N 가격 발행 로직과 함께 개별 종목 가격 발행 로직도 처리

2. 개별 시세 발행 로직 (publishSingleTickerPrice)
- 수신된 체결 데이터를 기반으로, 시가 대비 등락률 등의 정보를 계산하여 SingleTickerPriceResponse DTO를 생성
- 생성된 DTO를 Redis Pub/Sub의 SINGLE_TICKER_PRICE_CHANNEL 토픽으로 발행

3. 새로운 핸들러 추가 및 라우팅
- SingleTickerPriceHandler: SINGLE_TICKER_PRICE_CHANNEL을 구독하는 새로운 RedisMessageHandler 구현체
- 수신한 메시지를 SingleTickerPriceResponse로 파싱한 뒤, SimpMessageSendingOperations를 사용하여 동적인 STOMP 토픽 (예: /topic/crypto/price/BTC)으로 최종 브로드캐스팅