### PR TITLE
feat: 차트 초기화에 필요한 과거 캔들 데이터 조회 REST API 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/controller/CryptoController.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/controller/CryptoController.kt
@@ -1,0 +1,22 @@
+package com.zunza.buythedip_kotlin.crypto.controller
+
+import com.zunza.buythedip_kotlin.crypto.dto.KlineResponse
+import com.zunza.buythedip_kotlin.crypto.service.BinanceService
+import org.springframework.http.ResponseEntity
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class CryptoController(
+    private val binanceService: BinanceService
+) {
+    @GetMapping("/api/crypto/kline/{symbol}/{interval}")
+    fun getHistoricalKlineData(
+        @PathVariable(name = "symbol") symbol: String,
+        @PathVariable(name = "interval") interval: String = "15m",
+    ): ResponseEntity<List<KlineResponse>> {
+        return ResponseEntity.ok(binanceService.getHistoricalKlineData(symbol, interval).block()!!)
+    }
+}
+

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/KlineResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/KlineResponse.kt
@@ -1,0 +1,88 @@
+package com.zunza.buythedip_kotlin.crypto.dto
+
+import com.fasterxml.jackson.annotation.JsonInclude
+import com.fasterxml.jackson.databind.JsonNode
+
+data class KlineResponse(
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val symbol: String = "",
+    @JsonInclude(JsonInclude.Include.NON_EMPTY)
+    val interval: String = "",
+    val candle: CandleData,
+    val volume: VolumeData
+) {
+    companion object {
+        fun createHistoricalKlineResponse(node: JsonNode): KlineResponse {
+            return KlineResponse(
+                candle = CandleData.createHistoricalCandleData(node),
+                volume = VolumeData.createHistoricalVolumeData(node)
+            )
+        }
+
+        fun createRealtimeKlineResponse(klineData: KlineData): KlineResponse {
+            return KlineResponse(
+                klineData.symbol.removeSuffix("USDT"),
+                klineData.interval,
+                CandleData.createRealtimeCandleData(klineData),
+                VolumeData.createRealtimeVolumeData(klineData)
+            )
+        }
+    }
+
+    data class CandleData(
+        val time: Long,
+        val open: Double,
+        val high: Double,
+        val low: Double,
+        val close: Double,
+    ) {
+        companion object {
+            fun createHistoricalCandleData(node: JsonNode): CandleData {
+                return CandleData(
+                    node[0].asLong() / 1_000,
+                    node[1].asDouble(),
+                    node[2].asDouble(),
+                    node[3].asDouble(),
+                    node[4].asDouble()
+                )
+            }
+
+            fun createRealtimeCandleData(klineData: KlineData): CandleData {
+                return CandleData(
+                    klineData.time / 1_000,
+                    klineData.open,
+                    klineData.high,
+                    klineData.low,
+                    klineData.close
+                )
+            }
+        }
+    }
+
+    data class VolumeData(
+        val time: Long,
+        val value: Double,
+        val color: String
+    ) {
+        companion object {
+            private const val COLOR_BULLISH = "rgba(244, 67, 54, 1.0)"
+            private const val COLOR_BEARISH = "rgba(76, 175, 80, 1.0)"
+
+            fun createHistoricalVolumeData(node: JsonNode): VolumeData {
+                return VolumeData(
+                    node[0].asLong() / 1_000,
+                    node[5].asDouble(),
+                    if (node[1].asDouble() >= node[4].asDouble()) COLOR_BULLISH else COLOR_BEARISH
+                )
+            }
+
+            fun createRealtimeVolumeData(klineData: KlineData): VolumeData {
+                return VolumeData(
+                    klineData.time,
+                    klineData.volume,
+                    if (klineData.open >= klineData.close) COLOR_BULLISH else COLOR_BEARISH
+                )
+            }
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/service/BinanceService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/service/BinanceService.kt
@@ -2,6 +2,7 @@ package com.zunza.buythedip_kotlin.crypto.service
 
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.zunza.buythedip_kotlin.crypto.binance.stream.client.BinanceClient
+import com.zunza.buythedip_kotlin.crypto.dto.KlineResponse
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 import reactor.core.publisher.Mono
@@ -19,6 +20,12 @@ class BinanceService(
             .onErrorReturn(Double.NaN)
     }
 
+    fun getHistoricalKlineData(symbol: String, interval: String, limit: Int = 200): Mono<List<KlineResponse>> {
+        return binanceClient.getKlineData(symbol + "USDT", interval, limit)
+            .map { jsonString -> parseKlineData(jsonString) }
+            .onErrorReturn(emptyList())
+    }
+
     private fun parseOpenPrice(klineData: String, symbol: String): Double {
         val jsonNode = objectMapper.readTree(klineData)
         if (jsonNode.isNull || jsonNode.isEmpty) {
@@ -28,5 +35,17 @@ class BinanceService(
 
         val klineData = jsonNode.get(0)
         return klineData.get(1).asText().toDouble()
+    }
+
+    private fun parseKlineData(jsonString: String): List<KlineResponse> {
+        val rootNode = objectMapper.readTree(jsonString)
+        if (rootNode.isNull || rootNode.isEmpty) {
+            logger.warn { "No Kline data found" }
+            return emptyList()
+        }
+
+        return rootNode.map { klineData ->
+            KlineResponse.createHistoricalKlineResponse(klineData)
+        }
     }
 }


### PR DESCRIPTION
1. REST API 엔드포인트 구현
- GET /api/crypto/kline/{symbol}/{interval} 경로를 통해 특정 암호화폐(symbol)와 시간 간격(interval)에 대한 과거 Kline 데이터를 요청할 수 있는 API를 구현

2. 비동기 데이터 조회 (BinanceService)
- BinanceService.getHistoricalKlineData() 메서드는 WebClient를 동기적으로 사용 중. 추후 개선 예정