### PR TITLE
feat: On-demand 실시간 차트 데이터 스트리밍 시스템 구축

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisListenerConfig.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/config/RedisListenerConfig.kt
@@ -35,6 +35,11 @@ class RedisListenerConfig(
     }
 
     @Bean
+    fun singleTickerKlineChannelTopic(): ChannelTopic {
+        return ChannelTopic(SINGLE_TICKER_KLINE_CHANNEL.topic)
+    }
+
+    @Bean
     fun listenerAdapter(): MessageListenerAdapter {
         return MessageListenerAdapter(subscriber, "sendMessage")
     }
@@ -47,6 +52,7 @@ class RedisListenerConfig(
         container.addMessageListener(listenerAdapter(), topVolumeTickerSummaryChannelTopic())
         container.addMessageListener(listenerAdapter(), topVolumeTickerPriceChannelTopic())
         container.addMessageListener(listenerAdapter(), singleTickerPriceChannelTopic())
+        container.addMessageListener(listenerAdapter(), singleTickerKlineChannelTopic())
         return container
     }
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/client/KlineWebSocketClient.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/client/KlineWebSocketClient.kt
@@ -1,0 +1,56 @@
+package com.zunza.buythedip_kotlin.crypto.binance.stream.client
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zunza.buythedip_kotlin.crypto.binance.stream.manager.KlineStreamManager
+import com.zunza.buythedip_kotlin.crypto.dto.KlineStreamResponse
+import com.zunza.buythedip_kotlin.crypto.service.CryptoService
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+import org.springframework.web.socket.client.WebSocketClient
+import org.springframework.web.socket.handler.TextWebSocketHandler
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class KlineWebSocketClient(
+    private val webSocketClient: WebSocketClient,
+    private val objectMapper: ObjectMapper,
+    private val klineStreamManager: KlineStreamManager,
+    private val cryptoService: CryptoService
+) : TextWebSocketHandler() {
+
+    companion object {
+        private const val URL = "wss://data-stream.binance.vision/stream"
+    }
+
+    @EventListener(ApplicationReadyEvent::class)
+    fun connect() {
+        try {
+            webSocketClient.execute(this, URL)
+            logger.info { "Binance WebSocket Connected.. Type: [KLINE]" }
+        } catch (e: Exception) {
+            logger.warn { e.message }
+        }
+    }
+
+    override fun afterConnectionEstablished(session: WebSocketSession) {
+        klineStreamManager.registerKlineSession(session)
+    }
+
+    override fun handleTextMessage(
+        session: WebSocketSession,
+        message: TextMessage
+    ) {
+        val klineStreamResponse = objectMapper.readValue(
+            message.payload,
+            KlineStreamResponse::class.java
+            )
+
+        val kline = klineStreamResponse.kline ?: return
+        cryptoService.publishKlineData(kline.klineData!!)
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/manager/KlineStreamManager.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/manager/KlineStreamManager.kt
@@ -1,0 +1,55 @@
+package com.zunza.buythedip_kotlin.crypto.binance.stream.manager
+
+import com.fasterxml.jackson.databind.ObjectMapper
+import com.zunza.buythedip_kotlin.crypto.dto.SubscribeRequest
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.TextMessage
+import org.springframework.web.socket.WebSocketSession
+
+private val logger = KotlinLogging.logger {  }
+
+@Component
+class KlineStreamManager(
+    private val objectMapper: ObjectMapper,
+) {
+    companion object {
+        private const val SYMBOL_SUFFIX = "usdt"
+        private const val INTERVAL_PREFIX = "@kline_"
+    }
+
+    private var currentSession: WebSocketSession? = null
+
+    fun registerKlineSession(session: WebSocketSession) {
+        this.currentSession = session
+    }
+
+    fun subscribeKline(symbol: String, interval: String) {
+        val params = symbol + SYMBOL_SUFFIX + INTERVAL_PREFIX + interval
+        sendMessage("SUBSCRIBE", listOf(params))
+    }
+
+    fun unsubscribeCombinedKline(params: List<String>) {
+        sendMessage("UNSUBSCRIBE", params)
+    }
+
+    fun unsubscribeKline(symbol: String, interval: String) {
+        val params = symbol + SYMBOL_SUFFIX + INTERVAL_PREFIX + interval
+        sendMessage("UNSUBSCRIBE", listOf(params))
+    }
+
+    fun sendMessage(method: String, params: List<String>) {
+        try {
+            val payload = objectMapper.writeValueAsString(
+                SubscribeRequest(
+                    method,
+                    params,
+                    this.currentSession?.id.toString()
+                )
+            )
+            this.currentSession?.sendMessage(TextMessage(payload))
+        } catch (e: Exception) {
+            throw e
+        }
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/stompSession/StompSessionEventListener.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/binance/stream/stompSession/StompSessionEventListener.kt
@@ -1,0 +1,113 @@
+package com.zunza.buythedip_kotlin.crypto.binance.stream.stompSession
+
+import com.zunza.buythedip_kotlin.crypto.binance.stream.manager.KlineStreamManager
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.context.event.EventListener
+import org.springframework.data.redis.connection.ReturnType
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.messaging.simp.stomp.StompHeaderAccessor
+import org.springframework.stereotype.Component
+import org.springframework.web.socket.messaging.SessionDisconnectEvent
+import org.springframework.web.socket.messaging.SessionSubscribeEvent
+import org.springframework.web.socket.messaging.SessionUnsubscribeEvent
+
+private val logger = KotlinLogging.logger {  }
+
+/**
+ * 페이지 이동 시: Unsubscribe -> Disconnect
+ * 탭 종료 시 (강종): Disconnect
+ */
+
+@Component
+class StompSessionEventListener(
+    private val redisTemplate: RedisTemplate<String, Any>,
+    private val klineStreamManager: KlineStreamManager
+) {
+    companion object {
+        private const val KLINE_TOPIC_PREFIX = "/topic/crypto/kline/"
+    }
+
+    @EventListener
+    fun handleSessionSubscribe(event: SessionSubscribeEvent) {
+        logger.info{ "Subscribe" }
+
+        val accessor: StompHeaderAccessor = StompHeaderAccessor.wrap(event.message)
+        val sessionId = accessor.sessionId ?: return
+        val subscriptionId = accessor.subscriptionId ?: return
+        val destination = accessor.destination ?: return
+
+        if (!destination.startsWith(KLINE_TOPIC_PREFIX)) return
+
+        val count: Long? = redisTemplate.opsForValue().increment(destination) ?: 0L
+        redisTemplate.opsForValue().set(subscriptionId, destination)
+        redisTemplate.opsForSet().add(sessionId, subscriptionId)
+
+        if (count == 1L) {
+            val(symbol, interval) = destination
+                .removePrefix(KLINE_TOPIC_PREFIX)
+                .split("/")
+
+            klineStreamManager.subscribeKline(symbol.lowercase(), interval)
+        }
+    }
+
+    @EventListener
+    fun handleSessionUnsubscribe(event: SessionUnsubscribeEvent) {
+        logger.info{ "Unsubscribe" }
+
+        val accessor: StompHeaderAccessor = StompHeaderAccessor.wrap(event.message)
+        val sessionId = accessor.sessionId ?: return
+        val subscriptionId = accessor.subscriptionId ?: return
+
+        val destination = redisTemplate.opsForValue().get(subscriptionId)
+            ?.toString()
+            ?: return
+
+        if (!destination.startsWith(KLINE_TOPIC_PREFIX)) return
+
+        safeDecrement(destination)
+        redisTemplate.delete(subscriptionId)
+        redisTemplate.opsForSet().remove(sessionId, subscriptionId)
+    }
+
+    @EventListener
+    fun handleDisconnect(event: SessionDisconnectEvent) {
+        logger.info{ "Disconnect" }
+
+        val accessor: StompHeaderAccessor = StompHeaderAccessor.wrap(event.message)
+        val sessionId = accessor.sessionId ?: return
+
+        val set = redisTemplate.opsForSet().members(sessionId) ?: return
+
+        if (set.isEmpty()) {
+            redisTemplate.delete(sessionId)
+        }
+
+        for (subscriptionId in set) {
+            val destination = redisTemplate.opsForValue().get(subscriptionId).toString()
+            safeDecrement(destination)
+        }
+
+        redisTemplate.delete(sessionId)
+    }
+
+    private fun safeDecrement(key: String): Long {
+        val script = """
+            local count = redis.call('GET', KEYS[1])
+            count = tonumber(count) or 0
+            if count > 0 then
+                count = redis.call('DECR', KEYS[1])
+            end
+            return count
+        """.trimIndent()
+
+        return redisTemplate.execute<Long> { connection ->
+            connection.scriptingCommands().eval(
+                script.toByteArray(),
+                ReturnType.INTEGER,
+                1,
+                key.toByteArray()
+            ) as? Long
+        } ?: 0L
+    }
+}

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/KlineStreamResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/KlineStreamResponse.kt
@@ -1,0 +1,46 @@
+package com.zunza.buythedip_kotlin.crypto.dto
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties
+import com.fasterxml.jackson.annotation.JsonProperty
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KlineStreamResponse(
+
+    @JsonProperty("data")
+    val kline: Kline?
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class Kline(
+
+    @JsonProperty("k")
+    val klineData: KlineData?
+)
+
+@JsonIgnoreProperties(ignoreUnknown = true)
+data class KlineData(
+
+    @JsonProperty("t")
+    val time: Long,
+
+    @JsonProperty("s")
+    val symbol: String,
+
+    @JsonProperty("i")
+    val interval: String,
+
+    @JsonProperty("o")
+    val open: Double,
+
+    @JsonProperty("c")
+    val close: Double,
+
+    @JsonProperty("h")
+    val high: Double,
+
+    @JsonProperty("l")
+    val low: Double,
+
+    @JsonProperty("v")
+    val volume: Double
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/TradeStreamResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/TradeStreamResponse.kt
@@ -4,14 +4,14 @@ import com.fasterxml.jackson.annotation.JsonIgnoreProperties
 import com.fasterxml.jackson.annotation.JsonProperty
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class TradeStreamResponse(
+data class TradeStreamResponse(
 
     @JsonProperty("data")
     val tradeData: TradeData?
 )
 
 @JsonIgnoreProperties(ignoreUnknown = true)
-class TradeData(
+data class TradeData(
 
     @JsonProperty("s")
     val symbol: String,

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/scheduler/CryptoMarketDataScheduler.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/scheduler/CryptoMarketDataScheduler.kt
@@ -1,9 +1,14 @@
 package com.zunza.buythedip_kotlin.crypto.scheduler
 
+import com.zunza.buythedip_kotlin.crypto.binance.stream.manager.KlineStreamManager
 import com.zunza.buythedip_kotlin.crypto.service.BinanceService
 import com.zunza.buythedip_kotlin.crypto.service.CryptoService
 import io.github.oshai.kotlinlogging.KotlinLogging
 import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.springframework.boot.context.event.ApplicationReadyEvent
+import org.springframework.context.event.EventListener
+import org.springframework.data.redis.core.KeyScanOptions
+import org.springframework.data.redis.core.RedisTemplate
 import org.springframework.scheduling.annotation.Scheduled
 import org.springframework.stereotype.Service
 
@@ -13,6 +18,8 @@ private val logger = KotlinLogging.logger {  }
 class CryptoMarketDataScheduler(
     private val binanceService: BinanceService,
     private val cryptoService: CryptoService,
+    private val redisTemplate: RedisTemplate<String, Any>,
+    private val klineStreamManager: KlineStreamManager
 ) {
     companion object{
         private const val SYMBOL_SUFFIX = "USDT"
@@ -23,7 +30,7 @@ class CryptoMarketDataScheduler(
         private const val TOP_N = 50L
     }
 
-    @Scheduled(cron = "7 0 0 * * *", zone = "UTC")
+    @Scheduled(cron = "3 0 0 * * *", zone = "UTC")
     @SchedulerLock(name = "CryptoMarketScheduler_updateDailyOpenPrice")
 //    @EventListener(ApplicationReadyEvent::class)
 fun updateDailyOpenPrice() {
@@ -60,5 +67,46 @@ fun updateDailyOpenPrice() {
 
         cryptoService.cacheTopNTickerSymbols(tickers)
         cryptoService.publishTopNTickerSummaries(tickers)
+    }
+
+    @Scheduled(cron = "0 0/30 * * * *")
+    @SchedulerLock(
+        name = "CryptoMarketDataScheduler_unsubscribeKline"
+    )
+    fun unsubscribeKline() {
+        val keyPrefix = "/topic/crypto/kline/"
+        val keys = getSubscriptionKlineKeys("$keyPrefix*")
+
+        val params = keys.mapNotNull { key ->
+            if (redisTemplate.opsForValue().get(key) == 0) {
+                redisTemplate.delete(key)
+                val (symbol, interval) = key.removePrefix(keyPrefix).split("/", limit = 2)
+                "${symbol.lowercase()}usdt@kline_$interval"
+            } else {
+                null
+            }
+        }
+
+        klineStreamManager.unsubscribeCombinedKline(params)
+    }
+
+    private fun getSubscriptionKlineKeys(pattern: String): Set<String> {
+        val scanOptions = KeyScanOptions.scanOptions()
+            .match(pattern)
+            .count(50)
+            .build()
+
+        return redisTemplate.execute { connection ->
+            val stringSerializer = redisTemplate.stringSerializer
+            val results = mutableSetOf<String>()
+
+            connection.keyCommands().scan(scanOptions).use { cursor ->
+                while (cursor.hasNext()) {
+                    val key = stringSerializer.deserialize(cursor.next())
+                    key?.let { results.add(it) }
+                }
+            }
+            results
+        } ?: emptySet()
     }
 }


### PR DESCRIPTION
문제 상황: 4000개 스트림(암호화폐 수 400 * 인터벌 종류 10)
- 4000개에 달하는 모든 Kline 스트림을 서비스 시작 시점에 미리 구독하는 것은 규모가 작은 서버에 부담 됌
- 바이낸스 구독 제한 초과: 단일 연결의 최대 구독 가능 스트림(1024개)을 훨씬 초과
- 데이터 수신량: 아무도 보고 있지 않은 수천 개의 스트림에서 쏟아지는 데이터를 처리해야 하므로, 네트워크 트래픽과 서버 CPU 리소스가 낭비

1. 실시간 구독자 수 추적
- STOMP SessionSubscribeEvent와 SessionUnsubscribeEvent를 리스닝하여, 차트 토픽을 보고 있는 사용자가 있는지 없는지 카운트
- 각 토픽(/topic/crypto/kline/{symbol}/{interval}_)별 현재 구독자 수를 Redis에 카운팅하여, 모든 서버 인스턴스가 정확한 구독자 수를 공유
- DECR이 음수 값을 가질 수 있는 문제를 해결하기 위해, Lua 스크립트를 사용하여 값이 0보다 클 때만 감소시키는 원자적인 연산 구현

2. 주문형 바이낸스 구독/해제 (KlineStreamManager & StompSessionEventListener)
- 특정 토픽의 구독자 수가 0에서 1이 되는 순간, StompSessionEventListener는 KlineStreamManager를 호출하여 실시간으로 바이낸스에 해당 Kline 스트림(btcusdt@kline_1m) 구독을 요청
- 구독자 수가 1에서 0이 되어도 즉시 구독을 해제하지 않음 (사용자의 잦은 페이지 이동으로 인한 반복적인 구독/해제 방지)

3. 주기적인 비활성 스트림 정리 (CryptoMarketDataScheduler)
- 30분마다 Redis에 저장된 모든 Kline 토픽 키를 SCAN 명령으로 조회
- 조회된 토픽 중 구독자 수가 0인 토픽들을 찾아내어, KlineStreamManager를 통해 바이낸스에 해당 스트림들의 구독 해제를 한꺼번에 요청