### PR TITLE
feat: 암호화폐 상세 정보(소개, 웹사이트 등) 조회 API 구현

### DIFF
--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/controller/CryptoController.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/controller/CryptoController.kt
@@ -6,6 +6,7 @@ import com.zunza.buythedip_kotlin.crypto.service.CryptoService
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
@@ -17,12 +18,17 @@ class CryptoController(
     fun getTopNTickerSummaries() = ResponseEntity.ok(cryptoService.getTopNTickerSummaries())
 
 
-    @GetMapping("/api/cryptos/kline/{symbol}/{interval}")
+    @GetMapping("/api/cryptos/kline")
     fun getHistoricalKlineData(
-        @PathVariable(name = "symbol") symbol: String,
-        @PathVariable(name = "interval") interval: String = "15m",
+        @RequestParam(name = "symbol") symbol: String,
+        @RequestParam(name = "interval") interval: String = "15m",
     ): ResponseEntity<List<KlineResponse>> {
         return ResponseEntity.ok(binanceService.getHistoricalKlineData(symbol, interval).block()!!)
     }
+
+    @GetMapping("/api/cryptos/{id}/info")
+    fun getCryptoInformation(
+        @PathVariable id: Long
+    ) = ResponseEntity.ok(cryptoService.getCryptoInformation(id))
 }
 

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/CryptoInformationResponse.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/dto/CryptoInformationResponse.kt
@@ -1,0 +1,12 @@
+package com.zunza.buythedip_kotlin.crypto.dto
+
+data class CryptoInformationResponse(
+    val name: String = "",
+    val symbol: String = "",
+    val logo: String = "",
+    val description: String = "",
+    val website: List<String> = emptyList(),
+    val twitter: List<String> = emptyList(),
+    val explorer: List<String> = emptyList(),
+    val tagNames: List<String> = emptyList(),
+)

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoRepository.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/repository/CryptoRepository.kt
@@ -1,10 +1,12 @@
 package com.zunza.buythedip_kotlin.crypto.repository
 
+import com.zunza.buythedip_kotlin.crypto.dto.CryptoInformationResponse
 import com.zunza.buythedip_kotlin.crypto.dto.CryptoWithLogoDto
 import com.zunza.buythedip_kotlin.crypto.entity.Crypto
 import org.springframework.cache.annotation.Cacheable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 import org.springframework.stereotype.Repository
 
 @Repository
@@ -22,4 +24,22 @@ interface CryptoRepository : JpaRepository<Crypto, Long> {
         """)
     @Cacheable(cacheNames = ["CRYPTO:WITH:LOGO"])
     fun findAllWithLogo(): List<CryptoWithLogoDto>
+
+    @Query("""
+        SELECT new com.zunza.buythedip_kotlin.crypto.dto.CryptoInformationResponse(
+        c.name,
+        c.symbol,
+        m.logo,
+        m.description,
+		m.website,
+		m.twitter,
+		m.explorer,
+		m.tagNames
+        )
+        FROM Crypto c
+        JOIN c.metadata m
+        WHERE c.id = :id
+    """)
+    @Cacheable(cacheNames = ["CRYPTO:INFORMATION"])
+    fun findByIdWithMetadata(@Param("id") id :Long): CryptoInformationResponse
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/service/CryptoService.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/crypto/service/CryptoService.kt
@@ -1,5 +1,6 @@
 package com.zunza.buythedip_kotlin.crypto.service
 
+import com.zunza.buythedip_kotlin.crypto.dto.CryptoInformationResponse
 import com.zunza.buythedip_kotlin.crypto.dto.CryptoWithLogoDto
 import com.zunza.buythedip_kotlin.crypto.dto.KlineData
 import com.zunza.buythedip_kotlin.crypto.dto.KlineResponse
@@ -113,6 +114,8 @@ class CryptoService(
             )
     }
 
+    fun getCryptoInformation(id: Long) = cryptoRepository.findByIdWithMetadata(id)
+
     private fun generateCurrentMinuteBucketKey(tradeTime: Long): String {
         val tradeDateTime = LocalDateTime.ofInstant(
             Instant.ofEpochMilli(tradeTime),
@@ -172,5 +175,4 @@ class CryptoService(
     }
 
     private fun getChangePrice(symbol: String, currentPrice: Double) = currentPrice - getOpenPrice(symbol)
-
 }

--- a/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/constants/CacheType.kt
+++ b/src/main/kotlin/com/zunza/buythedip_kotlin/infrastructure/redis/constants/CacheType.kt
@@ -8,5 +8,6 @@ enum class CacheType(
 ) {
     NEWS_PAGE("NEWS:PAGE", Duration.ofMinutes(30)),
     NEWS_DETAIL("NEWS:DETAIL", Duration.ofMinutes(10)),
-    CRYPTO_WITH_LOGO("CRYPTO:WITH:LOGO", Duration.ofMinutes(60))
+    CRYPTO_WITH_LOGO("CRYPTO:WITH:LOGO", Duration.ofMinutes(60)),
+    CRYPTO_INFORMATION("CRYPTO:INFORMATION", Duration.ofMinutes(10))
 }


### PR DESCRIPTION
1. API 엔드포인트 구현 (CryptoController)
- GET /api/cryptos/{id}/info 경로를 통해 특정 암호화폐의 상세 정보를 조회할 수 있는 REST API를 구현

2. 효율적인 데이터 조회 (Repository Layer)
- JPQL DTO 프로젝션: CryptoRepository.findByIdWithMetadata() 메서드에서 @Query 어노테이션과 JPQL의 new 연산자를 사용
- Crypto와 Metadata 엔티티 전체를 영속성 컨텍스트에 로드하는 대신, 쿼리 결과로부터 직접 CryptoInformationResponse DTO를 생성
- Crypto와 Metadata 테이블을 JOIN하여, 단 한 번의 쿼리로 모든 필요한 정보를 가져와 N+1 문제를 방지

3. 캐싱 (@Cacheable)
- findByIdWithMetadata() 캐시 @Cacheable 적용